### PR TITLE
Рефакторинг спортивного события

### DIFF
--- a/src/main/java/ru/kappers/logic/controller/FixtureController.java
+++ b/src/main/java/ru/kappers/logic/controller/FixtureController.java
@@ -3,53 +3,49 @@ package ru.kappers.logic.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import ru.kappers.model.Fixture;
+import ru.kappers.model.Fixture.Status;
 import ru.kappers.service.FixtureService;
 
 import java.sql.Timestamp;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
 @RestController
 @RequestMapping(value = "/rest/fixture")
 public class FixtureController {
-    @Autowired
-    private FixtureService service;
+    private final FixtureService service;
 
-    @ResponseBody
+    @Autowired
+    public FixtureController(FixtureService service) {
+        this.service = service;
+    }
+
     @RequestMapping(value = "/nextweek", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Fixture> getNextWeek() {
-        return service.getFixturesNextWeek("Not Started");
+        return service.getFixturesNextWeek(Status.NOT_STARTED);
     }
 
-    @ResponseBody
     @RequestMapping(value = "/lastweek", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Fixture> getLastWeek() {
-        return service.getFixturesLastWeek("Match Finished");
+        return service.getFixturesLastWeek(Status.MATCH_FINISHED);
     }
 
-    @ResponseBody
     @RequestMapping(value = "/{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public Fixture getNextWeek(@PathVariable int id) {
         return service.getById(id);
-
     }
 
-    @ResponseBody
     @RequestMapping(value = "/today", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Fixture> getFixturesToday() {
         return service.getFixturesToday();
     }
 
-    @ResponseBody
     @RequestMapping(value = "/period", method = RequestMethod.GET)
     public List<Fixture> getFixturesByPeriod(
             @RequestParam("from") @DateTimeFormat(pattern = "yyyy-MM-dd") Date fromDate,
             @RequestParam("to") @DateTimeFormat(pattern = "yyyy-MM-dd") Date toDate) {
-
         return service.getFixturesByPeriod(new Timestamp(fromDate.getTime()), new Timestamp(toDate.getTime()));
     }
 }

--- a/src/main/java/ru/kappers/model/Fixture.java
+++ b/src/main/java/ru/kappers/model/Fixture.java
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nullable;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * JPA-сущность Спортивное событие
@@ -31,43 +33,47 @@ public class Fixture implements Serializable, Comparable {
 ////    private int Id;
     @Id
     @Column(name = "fixture_id",nullable = false, insertable = false, updatable = false)
-    Integer id;
+    private Integer id;
     @Column(name="event_timestamp")
-    Long eventTimestamp;
+    private Long eventTimestamp;
     @Column(name="event_date")
-    Timestamp eventDate;
+    private Timestamp eventDate;
     @Column(name="league_id")
-    Integer leagueId;
+    private Integer leagueId;
     @Column(name="round")
-    String round;
+    private String round;
     @Column(name="homeTeam_id")
-    Integer homeTeamId;
+    private Integer homeTeamId;
     @Column(name="awayTeam_id")
-    Integer awayTeamId;
+    private Integer awayTeamId;
     @Column(name="homeTeam")
-    String homeTeam;
+    private String homeTeam;
     @Column(name="awayTeam")
-    String awayTeam;
+    private String awayTeam;
+    /** Статус */
     @Column(name="status")
-    String status;
+    @Convert(converter = StatusConverter.class)
+    private Status status;
+    /** Сокращенный статус */
     @Column(name="statusShort")
-    String statusShort;
+    @Convert(converter = ShortStatusConverter.class)
+    private ShortStatus statusShort;
     @Column(name="goalsHomeTeam")
-    Integer goalsHomeTeam;
+    private Integer goalsHomeTeam;
     @Column(name="goalsAwayTeam")
-    Integer goalsAwayTeam;
+    private Integer goalsAwayTeam;
     @Column(name="halftime_score")
-    String halftimeScore;
+    private String halftimeScore;
     @Column(name="final_score")
-    String finalScore;
+    private String finalScore;
     @Column(name="penalty")
-    String penalty;
+    private String penalty;
     @Column(name="elapsed")
-    Integer elapsed;
+    private Integer elapsed;
     @Column(name="firstHalfStart")
-    Long firstHalfStart;
+    private Long firstHalfStart;
     @Column(name="secondHalfStart")
-    Long secondHalfStart;
+    private Long secondHalfStart;
     @OneToMany(mappedBy = "fixture")
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
@@ -85,5 +91,99 @@ public class Fixture implements Serializable, Comparable {
     @Override
     public int compareTo(Object o) {
         return eventTimestamp.compareTo(((Fixture) o).eventTimestamp);
+    }
+
+    /**
+     * Статус спортивного события
+     */
+    @Getter
+    @AllArgsConstructor
+    @ToString
+    public enum Status {
+        /** Спортивное событие не началось */
+        NOT_STARTED("Not Started"),
+        /** Матч закончен */
+        MATCH_FINISHED("Match Finished");
+
+        /** Значение статуса */
+        private final String value;
+
+        /**
+         * Найти статус по значению
+         * @param value значение статуса
+         * @return найденный статус или {@literal null}
+         */
+        @Nullable
+        public static Status byValue(String value) {
+            for (Status val : Status.values()) {
+                if (Objects.equals(value, val.value)) {
+                    return val;
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Сокращенный статус спортивного события
+     */
+    @Getter
+    @AllArgsConstructor
+    @ToString
+    public enum ShortStatus {
+        /** Спортивное событие не началось */
+        NOT_STARTED("NS"),
+        /** Матч закончен */
+        MATCH_FINISHED("FT");
+
+        /** Значение статуса */
+        private final String value;
+
+        /**
+         * Найти статус по значению
+         * @param value значение статуса
+         * @return найденный статус или {@literal null}
+         */
+        @Nullable
+        public static ShortStatus byValue(String value) {
+            for (ShortStatus val : ShortStatus.values()) {
+                if (Objects.equals(value, val.value)) {
+                    return val;
+                }
+            }
+            return null;
+        }
+    }
+
+    @Converter
+    public static class StatusConverter implements AttributeConverter<Status, String> {
+        @Override
+        public String convertToDatabaseColumn(Status attribute) {
+            if (attribute == null) {
+                return null;
+            }
+            return attribute.getValue();
+        }
+
+        @Override
+        public Status convertToEntityAttribute(String dbData) {
+            return Status.byValue(dbData);
+        }
+    }
+
+    @Converter
+    public static class ShortStatusConverter implements AttributeConverter<ShortStatus, String> {
+        @Override
+        public String convertToDatabaseColumn(ShortStatus attribute) {
+            if (attribute == null) {
+                return null;
+            }
+            return attribute.getValue();
+        }
+
+        @Override
+        public ShortStatus convertToEntityAttribute(String dbData) {
+            return ShortStatus.byValue(dbData);
+        }
     }
 }

--- a/src/main/java/ru/kappers/repository/FixtureRepository.java
+++ b/src/main/java/ru/kappers/repository/FixtureRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import ru.kappers.model.Fixture;
+import ru.kappers.model.Fixture.Status;
 
 import java.sql.Timestamp;
 import java.util.List;
@@ -16,5 +17,5 @@ public interface FixtureRepository extends JpaRepository<Fixture, Integer> {
     List<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to);
 
     @Query(value = "select f FROM Fixture f WHERE f.eventDate > :from and f.eventDate < :to and f.status = :filter")
-    List<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to, @Param("filter") String filter);
+    List<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to, @Param("filter") Status filter);
 }

--- a/src/main/java/ru/kappers/service/FixtureService.java
+++ b/src/main/java/ru/kappers/service/FixtureService.java
@@ -1,6 +1,7 @@
 package ru.kappers.service;
 
 import ru.kappers.model.Fixture;
+import ru.kappers.model.Fixture.Status;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -17,12 +18,12 @@ public interface FixtureService {
     List<Fixture> getAll();
     List<Fixture> getFixturesByPeriod(Timestamp from, Timestamp to);
     List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to);
-    List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, String filter);
+    List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Status filter);
     List<Fixture> getFixturesToday();
-    List<Fixture> getFixturesToday(String filter);
+    List<Fixture> getFixturesToday(Status filter);
     List<Fixture> getFixturesLastWeek();
-    List<Fixture> getFixturesLastWeek(String filter);
+    List<Fixture> getFixturesLastWeek(Status filter);
     List<Fixture> getFixturesNextWeek();
-    List<Fixture> getFixturesNextWeek(String filter);
+    List<Fixture> getFixturesNextWeek(Status filter);
     Fixture getById(int id);
 }

--- a/src/main/java/ru/kappers/service/impl/FixtureServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/FixtureServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.kappers.model.Fixture;
+import ru.kappers.model.Fixture.Status;
 import ru.kappers.repository.FixtureRepository;
 import ru.kappers.service.FixtureService;
 
@@ -76,7 +77,7 @@ public class FixtureServiceImpl implements FixtureService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, String filter) {
+    public List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Status filter) {
         log.debug("getFixturesByPeriod(from: {}, to: {}, filter: {})...", from, to, filter);
         return repository.getFixturesByPeriod(Timestamp.valueOf(from), Timestamp.valueOf(to), filter);
     }
@@ -99,7 +100,7 @@ public class FixtureServiceImpl implements FixtureService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Fixture> getFixturesToday(String filter) {
+    public List<Fixture> getFixturesToday(Status filter) {
         log.debug("getFixturesToday(filter: {})...", filter);
         final LocalDate now = LocalDate.now();
         return getFixturesByPeriod(getFromNow(now), getToNow(now), filter);
@@ -115,7 +116,7 @@ public class FixtureServiceImpl implements FixtureService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Fixture> getFixturesLastWeek(String filter) {
+    public List<Fixture> getFixturesLastWeek(Status filter) {
         log.debug("getFixturesLastWeek(filter: {})...", filter);
         final LocalDate now = LocalDate.now();
         return getFixturesByPeriod(getFromNow(now).minusDays(7), getToNow(now), filter);
@@ -131,7 +132,7 @@ public class FixtureServiceImpl implements FixtureService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Fixture> getFixturesNextWeek(String filter) {
+    public List<Fixture> getFixturesNextWeek(Status filter) {
         log.debug("getFixturesNextWeek(filter: {})...", filter);
         final LocalDate now = LocalDate.now();
         return getFixturesByPeriod(getFromNow(now), getToNow(now).plusDays(7), filter);

--- a/src/test/java/ru/kappers/service/FixtureServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/FixtureServiceImplTest.java
@@ -15,6 +15,8 @@ import org.springframework.test.context.junit4.AbstractTransactionalJUnit4Spring
 import org.springframework.test.context.junit4.SpringRunner;
 import ru.kappers.KappersApplication;
 import ru.kappers.model.Fixture;
+import ru.kappers.model.Fixture.ShortStatus;
+import ru.kappers.model.Fixture.Status;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -29,8 +31,6 @@ import static org.junit.Assert.*;
 @SpringBootTest(classes = {KappersApplication.class})
 @TestExecutionListeners({DbUnitTestExecutionListener.class})
 public class FixtureServiceImplTest extends AbstractTransactionalJUnit4SpringContextTests {
-private static final String STATUS_NOT_STARTED = "Not Started";
-private static final String STATUS_MATCH_FINISHED = "Match Finished";
     @Autowired
     private FixtureService service;
     private Timestamp nowTstmp = new Timestamp(System.currentTimeMillis());
@@ -41,7 +41,8 @@ private static final String STATUS_MATCH_FINISHED = "Match Finished";
             .awayTeam("Real Madrid")
             .homeTeam("FC Barselona")
             .leagueId(87)
-            .status(STATUS_NOT_STARTED)
+            .status(Status.NOT_STARTED)
+            .statusShort(ShortStatus.NOT_STARTED)
             .build();
 
     private Fixture tomorrow = Fixture.builder()
@@ -51,7 +52,8 @@ private static final String STATUS_MATCH_FINISHED = "Match Finished";
             .awayTeam("Manchester United")
             .homeTeam("FC Liverpool")
             .leagueId(2)
-            .status(STATUS_NOT_STARTED)
+            .status(Status.NOT_STARTED)
+            .statusShort(ShortStatus.NOT_STARTED)
             .build();
 
     private Fixture yesterday = Fixture.builder()
@@ -61,7 +63,8 @@ private static final String STATUS_MATCH_FINISHED = "Match Finished";
             .awayTeam("Paris Saint Germain")
             .homeTeam("Lyon")
             .leagueId(4)
-            .status(STATUS_MATCH_FINISHED)
+            .status(Status.MATCH_FINISHED)
+            .statusShort(ShortStatus.MATCH_FINISHED)
             .build();
 
     private Fixture nextWeek = Fixture.builder()
@@ -71,7 +74,8 @@ private static final String STATUS_MATCH_FINISHED = "Match Finished";
             .awayTeam("Real Madrid")
             .homeTeam("FC Barselona")
             .leagueId(87)
-            .status(STATUS_NOT_STARTED)
+            .status(Status.NOT_STARTED)
+            .statusShort(ShortStatus.NOT_STARTED)
             .build();
 
     private Fixture lastWeek = Fixture.builder()
@@ -81,7 +85,8 @@ private static final String STATUS_MATCH_FINISHED = "Match Finished";
             .awayTeam("Paris Saint Germain")
             .homeTeam("Lyon")
             .leagueId(4)
-            .status(STATUS_MATCH_FINISHED)
+            .status(Status.MATCH_FINISHED)
+            .statusShort(ShortStatus.MATCH_FINISHED)
             .build();
 
     @Before
@@ -108,7 +113,6 @@ private static final String STATUS_MATCH_FINISHED = "Match Finished";
         Fixture record = service.addRecord(tomorrow);
         assertNotNull(record);
         assertEquals((long) record.getId(), (long) 112);
-        service.deleteRecord(record);
     }
 
     @Test
@@ -137,10 +141,10 @@ private static final String STATUS_MATCH_FINISHED = "Match Finished";
     public void updateFixture() {
         service.addRecord(tomorrow);
         Fixture fixture = service.getById(tomorrow.getId());
-        fixture.setStatus(STATUS_MATCH_FINISHED);
+        fixture.setStatus(Status.MATCH_FINISHED);
         service.updateFixture(fixture);
         Fixture updated = service.getById(tomorrow.getId());
-        assertEquals(updated.getStatus(), STATUS_MATCH_FINISHED);
+        assertEquals(updated.getStatus(), Status.MATCH_FINISHED);
         service.deleteRecord(updated);
     }
 
@@ -158,9 +162,6 @@ private static final String STATUS_MATCH_FINISHED = "Match Finished";
         assertTrue(containsToday);
         assertTrue(containsTomorrow);
         assertTrue(containsYesterday);
-        service.deleteRecord(today);
-        service.deleteRecord(tomorrow);
-        service.deleteRecord(yesterday);
     }
 
     @Test
@@ -172,10 +173,7 @@ private static final String STATUS_MATCH_FINISHED = "Match Finished";
         assertTrue(todaysFixtures.contains(today));
         assertFalse(todaysFixtures.contains(yesterday));
         assertFalse(todaysFixtures.contains(tomorrow));
-        service.deleteRecord(tomorrow);
-        service.deleteRecord(yesterday);
-        service.deleteRecord(today);
-
+        // вообще то нет необходимости возвращать к исходному состоянию, должна в каждом тесте откатываться транзакция
     }
 
     @Test
@@ -185,19 +183,15 @@ private static final String STATUS_MATCH_FINISHED = "Match Finished";
         assertTrue(fixturesToday.contains(today));
         assertFalse(fixturesToday.contains(yesterday));
         assertFalse(fixturesToday.contains(tomorrow));
-        service.deleteRecord(today);
     }
 
     @Test
     public void getFixturesTodayFiltered() {
         service.addRecord(today);
-        List<Fixture> fixturesToday = service.getFixturesToday(STATUS_NOT_STARTED);
+        List<Fixture> fixturesToday = service.getFixturesToday(Status.NOT_STARTED);
         assertTrue(fixturesToday.contains(today));
-        List<Fixture> fixturesToday2 = service.getFixturesToday(STATUS_MATCH_FINISHED);
+        List<Fixture> fixturesToday2 = service.getFixturesToday(Status.MATCH_FINISHED);
         assertFalse(fixturesToday2.contains(today));
-        service.deleteRecord(today);
-
-
     }
 
     @Test


### PR DESCRIPTION
В Спортивном событии заведены 2 enum-а для статуса события. Обновлен весь сопутствующий код, тесты.