### PR TITLE
Currency service

### DIFF
--- a/src/main/java/ru/kappers/service/parser/CBRFDailyCurrencyRatesParser.java
+++ b/src/main/java/ru/kappers/service/parser/CBRFDailyCurrencyRatesParser.java
@@ -3,6 +3,7 @@ package ru.kappers.service.parser;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ import java.util.Map;
 @Service
 public class CBRFDailyCurrencyRatesParser {
     private final JsonParser jsonParser = new JsonParser();
+    @Getter
     private final URL cbrfUrl;
 
     /** Ссылка на JSON курсов валют ЦБ РФ по умолчанию */
@@ -38,6 +40,7 @@ public class CBRFDailyCurrencyRatesParser {
     }
 
     public CBRFDailyCurrencyRatesParser(URL cbrfUrl) {
+        log.debug("CBRFDailyCurrencyRatesParser(cbrfUrl: {})...", cbrfUrl);
         this.cbrfUrl = cbrfUrl;
     }
 
@@ -47,6 +50,7 @@ public class CBRFDailyCurrencyRatesParser {
      * @throws RuntimeException если во время парсинга произошла ошибка
      */
     public List<CurrencyRate> parseFromCBRF() {
+        log.debug("parseFromCBRF()...");
         return parseFromURL(cbrfUrl);
     }
 
@@ -57,6 +61,13 @@ public class CBRFDailyCurrencyRatesParser {
      * @throws RuntimeException если во время парсинга произошла ошибка
      */
     public List<CurrencyRate> parseFromURL(URL url) {
+        log.debug("parseFromURL(url: {})...", url);
+        final String json = getJSONStringFromURL(url);
+        return parseFromJSON(json);
+    }
+
+    protected String getJSONStringFromURL(URL url) {
+        log.debug("getJSONStringFromURL(url: {})...", url);
         StringBuilder sb = new StringBuilder();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
             String s;
@@ -68,7 +79,7 @@ public class CBRFDailyCurrencyRatesParser {
             log.error(msg, e);
             throw new RuntimeException(msg, e);
         }
-        return parseFromJSON(sb.toString());
+        return sb.toString();
     }
 
     /**
@@ -77,6 +88,7 @@ public class CBRFDailyCurrencyRatesParser {
      * @return список курсов валют
      */
     public List<CurrencyRate> parseFromJSON(String json) {
+        log.debug("parseFromJSON(json: {})...", json);
         JsonObject object = (JsonObject) jsonParser.parse(json);
         Date date = DateTimeUtil.parseSqlDateFromZonedDateTime(object.get("Date").getAsString());
         JsonObject valutes = object.get("Valute").getAsJsonObject();

--- a/src/test/java/ru/kappers/service/impl/CurrencyServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/impl/CurrencyServiceImplTest.java
@@ -1,0 +1,74 @@
+package ru.kappers.service.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import ru.kappers.exceptions.CurrRateGettingException;
+import ru.kappers.model.CurrencyRate;
+import ru.kappers.service.CurrRateService;
+import ru.kappers.service.parser.CBRFDailyCurrencyRatesParser;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CurrencyServiceImplTest {
+    @InjectMocks
+    private CurrencyServiceImpl currencyService;
+    @Mock
+    private CurrRateService currRateService;
+    @Mock
+    private CBRFDailyCurrencyRatesParser currencyRatesParser;
+
+    @Test
+    public void refreshCurrencyRatesForTodayMustSaveRateIfTableHasNotRate() {
+        final Date currentDate = Date.valueOf(LocalDate.now());
+        final String usdCharCode = "USD";
+        final CurrencyRate currencyRate = CurrencyRate.builder()
+                .date(currentDate)
+                .charCode(usdCharCode)
+                .build();
+        final List<CurrencyRate> currencyRates = Arrays.asList(currencyRate);
+        when(currencyRatesParser.parseFromCBRF()).thenReturn(currencyRates);
+        when(currRateService.isExist(currentDate, usdCharCode)).thenReturn(false);
+
+        currencyService.refreshCurrencyRatesForToday();
+
+        verify(currencyRatesParser).parseFromCBRF();
+        verify(currRateService).isExist(currentDate, usdCharCode);
+        verify(currRateService).save(currencyRate);
+    }
+
+    @Test
+    public void refreshCurrencyRatesForTodayIfTableHasRate() {
+        final Date currentDate = Date.valueOf(LocalDate.now());
+        final String usdCharCode = "USD";
+        final CurrencyRate currencyRate = CurrencyRate.builder()
+                .date(currentDate)
+                .charCode(usdCharCode)
+                .build();
+        final List<CurrencyRate> currencyRates = Arrays.asList(currencyRate);
+        when(currencyRatesParser.parseFromCBRF()).thenReturn(currencyRates);
+        when(currRateService.isExist(currentDate, usdCharCode)).thenReturn(true);
+
+        currencyService.refreshCurrencyRatesForToday();
+
+        verify(currencyRatesParser).parseFromCBRF();
+        verify(currRateService).isExist(currentDate, usdCharCode);
+        verify(currRateService, never()).save(currencyRate);
+    }
+
+    @Test(expected = CurrRateGettingException.class)
+    public void refreshCurrencyRatesForTodayMustThrowExceptionIfParserThrowAnyException() {
+        when(currencyRatesParser.parseFromCBRF()).thenThrow(RuntimeException.class);
+
+        currencyService.refreshCurrencyRatesForToday();
+    }
+}

--- a/src/test/java/ru/kappers/service/parser/CBRFDailyCurrencyRatesParserTest.java
+++ b/src/test/java/ru/kappers/service/parser/CBRFDailyCurrencyRatesParserTest.java
@@ -1,0 +1,91 @@
+package ru.kappers.service.parser;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.util.ResourceUtils;
+import ru.kappers.model.CurrencyRate;
+import ru.kappers.util.DateTimeUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CBRFDailyCurrencyRatesParserTest {
+    @InjectMocks
+    private CBRFDailyCurrencyRatesParser currencyRatesParser = new CBRFDailyCurrencyRatesParser();
+
+    private final String testJSON;
+
+    public CBRFDailyCurrencyRatesParserTest() throws IOException {
+        File file = ResourceUtils.getFile("classpath:data/cbr_daily_json.js");
+        testJSON = new String(Files.readAllBytes(file.toPath()));
+    }
+
+    @Test
+    public void defaultConstructor() throws MalformedURLException {
+        currencyRatesParser = new CBRFDailyCurrencyRatesParser();
+
+        assertThat(currencyRatesParser.getCbrfUrl().toString(), is(CBRFDailyCurrencyRatesParser.CBRF_DAILY_JSON_DEFAULT_URL));
+    }
+
+    @Test
+    public void parseFromCBRFMustCallParseFromURL() {
+        final URL cbrfUrl = currencyRatesParser.getCbrfUrl();
+        currencyRatesParser = spy(currencyRatesParser);
+        final List<CurrencyRate> currencyRates = Arrays.asList(mock(CurrencyRate.class));
+        doReturn(currencyRates).when(currencyRatesParser).parseFromURL(cbrfUrl);
+
+        final List<CurrencyRate> result = currencyRatesParser.parseFromCBRF();
+
+        assertThat(result, is(currencyRates));
+        verify(currencyRatesParser).parseFromURL(cbrfUrl);
+    }
+
+    @Test
+    public void parseFromURL() {
+        final URL cbrfUrl = currencyRatesParser.getCbrfUrl();
+        currencyRatesParser = spy(currencyRatesParser);
+        doReturn(testJSON).when(currencyRatesParser).getJSONStringFromURL(cbrfUrl);
+
+        final List<CurrencyRate> result = currencyRatesParser.parseFromURL(cbrfUrl);
+
+        assertThat(result, is(notNullValue()));
+        assertThat(result.size(), is(34));
+        verify(currencyRatesParser).getJSONStringFromURL(cbrfUrl);
+        verify(currencyRatesParser).parseFromJSON(testJSON);
+    }
+
+    @Test
+    public void parseFromJSON() {
+        final List<CurrencyRate> currencyRates = currencyRatesParser.parseFromJSON(testJSON);
+
+        assertThat(currencyRates, is(notNullValue()));
+        assertThat(currencyRates.size(), is(34));
+
+        final CurrencyRate usdCurrencyRate = currencyRates.stream()
+                .filter(currencyRate -> "USD".equals(currencyRate.getCharCode()))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(usdCurrencyRate, is(notNullValue()));
+        assertThat(usdCurrencyRate.getNumCode(), is("840"));
+        assertThat(usdCurrencyRate.getCharCode(), is("USD"));
+        assertThat(usdCurrencyRate.getName(), is("Доллар США"));
+        assertThat(usdCurrencyRate.getDate(), is(DateTimeUtil.parseSqlDateFromZonedDateTime("2019-05-17T11:30:00+03:00")));
+        assertThat(usdCurrencyRate.getNominal(), is(1));
+        assertThat(usdCurrencyRate.getValue(), is(new BigDecimal("64.5598")));
+    }
+}

--- a/src/test/resources/data/cbr_daily_json.js
+++ b/src/test/resources/data/cbr_daily_json.js
@@ -1,0 +1,314 @@
+{
+    "Date": "2019-05-17T11:30:00+03:00",
+    "PreviousDate": "2019-05-16T11:30:00+03:00",
+    "PreviousURL": "\/\/www.cbr-xml-daily.ru\/archive\/2019\/05\/16\/daily_json.js",
+    "Timestamp": "2019-05-16T20:00:00+03:00",
+    "Valute": {
+    "AUD": {
+        "ID": "R01010",
+            "NumCode": "036",
+            "CharCode": "AUD",
+            "Nominal": 1,
+            "Name": "Австралийский доллар",
+            "Value": 44.727,
+            "Previous": 44.9014
+    },
+    "AZN": {
+        "ID": "R01020A",
+            "NumCode": "944",
+            "CharCode": "AZN",
+            "Nominal": 1,
+            "Name": "Азербайджанский манат",
+            "Value": 38.0547,
+            "Previous": 38.2251
+    },
+    "GBP": {
+        "ID": "R01035",
+            "NumCode": "826",
+            "CharCode": "GBP",
+            "Nominal": 1,
+            "Name": "Фунт стерлингов Соединенного королевства",
+            "Value": 82.8496,
+            "Previous": 83.7264
+    },
+    "AMD": {
+        "ID": "R01060",
+            "NumCode": "051",
+            "CharCode": "AMD",
+            "Nominal": 100,
+            "Name": "Армянских драмов",
+            "Value": 13.45,
+            "Previous": 13.4793
+    },
+    "BYN": {
+        "ID": "R01090B",
+            "NumCode": "933",
+            "CharCode": "BYN",
+            "Nominal": 1,
+            "Name": "Белорусский рубль",
+            "Value": 30.9091,
+            "Previous": 30.9778
+    },
+    "BGN": {
+        "ID": "R01100",
+            "NumCode": "975",
+            "CharCode": "BGN",
+            "Nominal": 1,
+            "Name": "Болгарский лев",
+            "Value": 37.0204,
+            "Previous": 37.1776
+    },
+    "BRL": {
+        "ID": "R01115",
+            "NumCode": "986",
+            "CharCode": "BRL",
+            "Nominal": 1,
+            "Name": "Бразильский реал",
+            "Value": 16.1339,
+            "Previous": 16.3076
+    },
+    "HUF": {
+        "ID": "R01135",
+            "NumCode": "348",
+            "CharCode": "HUF",
+            "Nominal": 100,
+            "Name": "Венгерских форинтов",
+            "Value": 22.3109,
+            "Previous": 22.3845
+    },
+    "HKD": {
+        "ID": "R01200",
+            "NumCode": "344",
+            "CharCode": "HKD",
+            "Nominal": 10,
+            "Name": "Гонконгских долларов",
+            "Value": 82.2491,
+            "Previous": 82.6122
+    },
+    "DKK": {
+        "ID": "R01215",
+            "NumCode": "208",
+            "CharCode": "DKK",
+            "Nominal": 10,
+            "Name": "Датских крон",
+            "Value": 96.9643,
+            "Previous": 97.3707
+    },
+    "USD": {
+        "ID": "R01235",
+            "NumCode": "840",
+            "CharCode": "USD",
+            "Nominal": 1,
+            "Name": "Доллар США",
+            "Value": 64.5598,
+            "Previous": 64.8489
+    },
+    "EUR": {
+        "ID": "R01239",
+            "NumCode": "978",
+            "CharCode": "EUR",
+            "Nominal": 1,
+            "Name": "Евро",
+            "Value": 72.3651,
+            "Previous": 72.6891
+    },
+    "INR": {
+        "ID": "R01270",
+            "NumCode": "356",
+            "CharCode": "INR",
+            "Nominal": 100,
+            "Name": "Индийских рупий",
+            "Value": 92.0376,
+            "Previous": 92.3083
+    },
+    "KZT": {
+        "ID": "R01335",
+            "NumCode": "398",
+            "CharCode": "KZT",
+            "Nominal": 100,
+            "Name": "Казахстанских тенге",
+            "Value": 17.0408,
+            "Previous": 17.0666
+    },
+    "CAD": {
+        "ID": "R01350",
+            "NumCode": "124",
+            "CharCode": "CAD",
+            "Nominal": 1,
+            "Name": "Канадский доллар",
+            "Value": 48.1107,
+            "Previous": 48.1361
+    },
+    "KGS": {
+        "ID": "R01370",
+            "NumCode": "417",
+            "CharCode": "KGS",
+            "Nominal": 100,
+            "Name": "Киргизских сомов",
+            "Value": 92.4263,
+            "Previous": 92.8402
+    },
+    "CNY": {
+        "ID": "R01375",
+            "NumCode": "156",
+            "CharCode": "CNY",
+            "Nominal": 10,
+            "Name": "Китайских юаней",
+            "Value": 93.8042,
+            "Previous": 94.3614
+    },
+    "MDL": {
+        "ID": "R01500",
+            "NumCode": "498",
+            "CharCode": "MDL",
+            "Nominal": 10,
+            "Name": "Молдавских леев",
+            "Value": 36.0166,
+            "Previous": 36.1527
+    },
+    "NOK": {
+        "ID": "R01535",
+            "NumCode": "578",
+            "CharCode": "NOK",
+            "Nominal": 10,
+            "Name": "Норвежских крон",
+            "Value": 74.2357,
+            "Previous": 74.1308
+    },
+    "PLN": {
+        "ID": "R01565",
+            "NumCode": "985",
+            "CharCode": "PLN",
+            "Nominal": 1,
+            "Name": "Польский злотый",
+            "Value": 16.8546,
+            "Previous": 16.8746
+    },
+    "RON": {
+        "ID": "R01585F",
+            "NumCode": "946",
+            "CharCode": "RON",
+            "Nominal": 1,
+            "Name": "Румынский лей",
+            "Value": 15.2102,
+            "Previous": 15.2715
+    },
+    "XDR": {
+        "ID": "R01589",
+            "NumCode": "960",
+            "CharCode": "XDR",
+            "Nominal": 1,
+            "Name": "СДР (специальные права заимствования)",
+            "Value": 89.2429,
+            "Previous": 89.7424
+    },
+    "SGD": {
+        "ID": "R01625",
+            "NumCode": "702",
+            "CharCode": "SGD",
+            "Nominal": 1,
+            "Name": "Сингапурский доллар",
+            "Value": 47.1721,
+            "Previous": 47.3938
+    },
+    "TJS": {
+        "ID": "R01670",
+            "NumCode": "972",
+            "CharCode": "TJS",
+            "Nominal": 10,
+            "Name": "Таджикских сомони",
+            "Value": 68.4077,
+            "Previous": 68.6973
+    },
+    "TRY": {
+        "ID": "R01700J",
+            "NumCode": "949",
+            "CharCode": "TRY",
+            "Nominal": 1,
+            "Name": "Турецкая лира",
+            "Value": 10.748,
+            "Previous": 10.702
+    },
+    "TMT": {
+        "ID": "R01710A",
+            "NumCode": "934",
+            "CharCode": "TMT",
+            "Nominal": 1,
+            "Name": "Новый туркменский манат",
+            "Value": 18.472,
+            "Previous": 18.5548
+    },
+    "UZS": {
+        "ID": "R01717",
+            "NumCode": "860",
+            "CharCode": "UZS",
+            "Nominal": 10000,
+            "Name": "Узбекских сумов",
+            "Value": 76.351,
+            "Previous": 76.6929
+    },
+    "UAH": {
+        "ID": "R01720",
+            "NumCode": "980",
+            "CharCode": "UAH",
+            "Nominal": 10,
+            "Name": "Украинских гривен",
+            "Value": 24.5148,
+            "Previous": 24.641
+    },
+    "CZK": {
+        "ID": "R01760",
+            "NumCode": "203",
+            "CharCode": "CZK",
+            "Nominal": 10,
+            "Name": "Чешских крон",
+            "Value": 28.1601,
+            "Previous": 28.2468
+    },
+    "SEK": {
+        "ID": "R01770",
+            "NumCode": "752",
+            "CharCode": "SEK",
+            "Nominal": 10,
+            "Name": "Шведских крон",
+            "Value": 67.2701,
+            "Previous": 67.5277
+    },
+    "CHF": {
+        "ID": "R01775",
+            "NumCode": "756",
+            "CharCode": "CHF",
+            "Nominal": 1,
+            "Name": "Швейцарский франк",
+            "Value": 64.0093,
+            "Previous": 64.4301
+    },
+    "ZAR": {
+        "ID": "R01810",
+            "NumCode": "710",
+            "CharCode": "ZAR",
+            "Nominal": 10,
+            "Name": "Южноафриканских рэндов",
+            "Value": 45.4964,
+            "Previous": 45.5441
+    },
+    "KRW": {
+        "ID": "R01815",
+            "NumCode": "410",
+            "CharCode": "KRW",
+            "Nominal": 1000,
+            "Name": "Вон Республики Корея",
+            "Value": 54.2389,
+            "Previous": 54.5343
+    },
+    "JPY": {
+        "ID": "R01820",
+            "NumCode": "392",
+            "CharCode": "JPY",
+            "Nominal": 100,
+            "Name": "Японских иен",
+            "Value": 58.9506,
+            "Previous": 59.2119
+    }
+}
+}


### PR DESCRIPTION
- Добавлены unit-тесты CurrencyServiceImplTest
- Рефакторинг парсера курсов валют для сайта ЦБ РФ:
- - добавленн getter для URL
- - добавлено логирование методов
- - выделен защищённый метод для получения строки JSON по URL
- Добавлены unit-тесты CBRFDailyCurrencyRatesParserTest и файл с тестовым JSON курсов валют