### PR TITLE
Selection with pagination

### DIFF
--- a/src/main/java/ru/kappers/logic/controller/FixtureController.java
+++ b/src/main/java/ru/kappers/logic/controller/FixtureController.java
@@ -24,18 +24,19 @@ public class FixtureController {
         this.service = service;
     }
 
-/*
     @RequestMapping(value = "/nextweek", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Fixture> getNextWeek() {
         return service.getFixturesNextWeek(Status.NOT_STARTED);
     }
-*/
 
+    //todo чтобы перейти к полноценному отображению данных с паджинацией надо будет web UI обучить не только отображать список содержимого, но и информацию по страницам и переходам по ним
 // пример тестового URL: http://localhost:8080/rest/fixture/nextweek?page=1&size=30&sort=eventDate
+/*
     @RequestMapping(value = "/nextweek", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public Page<Fixture> getNextWeek(Pageable pageable) {
         return service.getFixturesNextWeek(Status.NOT_STARTED, pageable);
     }
+*/
 
     @RequestMapping(value = "/lastweek", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Fixture> getLastWeek() {

--- a/src/main/java/ru/kappers/logic/controller/FixtureController.java
+++ b/src/main/java/ru/kappers/logic/controller/FixtureController.java
@@ -1,6 +1,8 @@
 package ru.kappers.logic.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -22,15 +24,30 @@ public class FixtureController {
         this.service = service;
     }
 
+/*
     @RequestMapping(value = "/nextweek", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Fixture> getNextWeek() {
         return service.getFixturesNextWeek(Status.NOT_STARTED);
+    }
+*/
+
+// пример тестового URL: http://localhost:8080/rest/fixture/nextweek?page=1&size=30&sort=eventDate
+    @RequestMapping(value = "/nextweek", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Page<Fixture> getNextWeek(Pageable pageable) {
+        return service.getFixturesNextWeek(Status.NOT_STARTED, pageable);
     }
 
     @RequestMapping(value = "/lastweek", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Fixture> getLastWeek() {
         return service.getFixturesLastWeek(Status.MATCH_FINISHED);
     }
+
+/*
+    @RequestMapping(value = "/lastweek", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Page<Fixture> getLastWeek(Pageable pageable) {
+        return service.getFixturesLastWeek(Status.MATCH_FINISHED, pageable);
+    }
+*/
 
     @RequestMapping(value = "/{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public Fixture getFixtureById(@PathVariable int id) {
@@ -42,10 +59,27 @@ public class FixtureController {
         return service.getFixturesToday();
     }
 
+/*
+    @RequestMapping(value = "/today", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public Page<Fixture> getFixturesToday(Pageable pageable) {
+        return service.getFixturesToday(pageable);
+    }
+*/
+
     @RequestMapping(value = "/period", method = RequestMethod.GET)
     public List<Fixture> getFixturesByPeriod(
             @RequestParam("from") @DateTimeFormat(pattern = "yyyy-MM-dd") Date fromDate,
             @RequestParam("to") @DateTimeFormat(pattern = "yyyy-MM-dd") Date toDate) {
         return service.getFixturesByPeriod(new Timestamp(fromDate.getTime()), new Timestamp(toDate.getTime()));
     }
+
+/*
+    @RequestMapping(value = "/period", method = RequestMethod.GET)
+    public Page<Fixture> getFixturesByPeriod(
+            @RequestParam("from") @DateTimeFormat(pattern = "yyyy-MM-dd") Date fromDate,
+            @RequestParam("to") @DateTimeFormat(pattern = "yyyy-MM-dd") Date toDate,
+            Pageable pageable) {
+        return service.getFixturesByPeriod(new Timestamp(fromDate.getTime()), new Timestamp(toDate.getTime()), pageable);
+    }
+*/
 }

--- a/src/main/java/ru/kappers/repository/FixtureRepository.java
+++ b/src/main/java/ru/kappers/repository/FixtureRepository.java
@@ -1,5 +1,7 @@
 package ru.kappers.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,9 +15,16 @@ import java.util.List;
  * Репозиторий для спортивных событий
  */
 public interface FixtureRepository extends JpaRepository<Fixture, Integer> {
-    @Query(value = "select f FROM Fixture f WHERE f.eventDate > :from and f.eventDate < :to")
+    @Query(value = "select f FROM Fixture f WHERE f.eventDate >= :from and f.eventDate <= :to")
     List<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to);
 
-    @Query(value = "select f FROM Fixture f WHERE f.eventDate > :from and f.eventDate < :to and f.status = :filter")
+    @Query(value = "select f FROM Fixture f WHERE f.eventDate >= :from and f.eventDate <= :to")
+    Page<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to, Pageable pageable);
+
+    @Query(value = "select f FROM Fixture f WHERE f.eventDate >= :from and f.eventDate <= :to and f.status = :filter")
     List<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to, @Param("filter") Status filter);
+
+    @Query(value = "select f FROM Fixture f WHERE f.eventDate >= :from and f.eventDate <= :to and f.status = :filter")
+    Page<Fixture> getFixturesByPeriod(@Param("from") Timestamp from, @Param("to") Timestamp to, @Param("filter") Status filter,
+                                      Pageable pageable);
 }

--- a/src/main/java/ru/kappers/service/FixtureService.java
+++ b/src/main/java/ru/kappers/service/FixtureService.java
@@ -1,5 +1,7 @@
 package ru.kappers.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import ru.kappers.model.Fixture;
 import ru.kappers.model.Fixture.Status;
 
@@ -16,14 +18,24 @@ public interface FixtureService {
     void deleteRecordById(int id);
     Fixture updateFixture (Fixture fixture);
     List<Fixture> getAll();
+    Page<Fixture> getAll(Pageable pageable);
     List<Fixture> getFixturesByPeriod(Timestamp from, Timestamp to);
+    Page<Fixture> getFixturesByPeriod(Timestamp from, Timestamp to, Pageable pageable);
     List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to);
+    Page<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Pageable pageable);
     List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Status filter);
+    Page<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Status filter, Pageable pageable);
     List<Fixture> getFixturesToday();
+    Page<Fixture> getFixturesToday(Pageable pageable);
     List<Fixture> getFixturesToday(Status filter);
+    Page<Fixture> getFixturesToday(Status filter, Pageable pageable);
     List<Fixture> getFixturesLastWeek();
+    Page<Fixture> getFixturesLastWeek(Pageable pageable);
     List<Fixture> getFixturesLastWeek(Status filter);
+    Page<Fixture> getFixturesLastWeek(Status filter, Pageable pageable);
     List<Fixture> getFixturesNextWeek();
+    Page<Fixture> getFixturesNextWeek(Pageable pageable);
     List<Fixture> getFixturesNextWeek(Status filter);
+    Page<Fixture> getFixturesNextWeek(Status filter, Pageable pageable);
     Fixture getById(int id);
 }

--- a/src/main/java/ru/kappers/service/impl/FixtureServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/FixtureServiceImpl.java
@@ -112,12 +112,12 @@ public class FixtureServiceImpl implements FixtureService {
         return repository.getFixturesByPeriod(Timestamp.valueOf(from), Timestamp.valueOf(to), filter, pageable);
     }
 
-    protected LocalDateTime getFromNow(LocalDate now) {
-        return LocalDateTime.of(now, LocalTime.MIN);
+    protected LocalDateTime getDayBegin(LocalDate date) {
+        return LocalDateTime.of(date, LocalTime.MIN);
     }
 
-    protected LocalDateTime getToNow(LocalDate now) {
-        return LocalDateTime.of(now, LocalTime.MAX);
+    protected LocalDateTime getDayEnd(LocalDate date) {
+        return LocalDateTime.of(date, LocalTime.MAX);
     }
 
     @Override
@@ -125,7 +125,7 @@ public class FixtureServiceImpl implements FixtureService {
     public List<Fixture> getFixturesToday() {
         log.debug("getFixturesToday()...");
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now), getToNow(now));
+        return getFixturesByPeriod(getDayBegin(now), getDayEnd(now));
     }
 
     @Override
@@ -133,7 +133,7 @@ public class FixtureServiceImpl implements FixtureService {
     public Page<Fixture> getFixturesToday(Pageable pageable) {
         log.debug("getFixturesToday(pageable)...");
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now), getToNow(now), pageable);
+        return getFixturesByPeriod(getDayBegin(now), getDayEnd(now), pageable);
     }
 
     @Override
@@ -141,7 +141,7 @@ public class FixtureServiceImpl implements FixtureService {
     public List<Fixture> getFixturesToday(Status filter) {
         log.debug("getFixturesToday(filter: {})...", filter);
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now), getToNow(now), filter);
+        return getFixturesByPeriod(getDayBegin(now), getDayEnd(now), filter);
     }
 
     @Override
@@ -149,7 +149,7 @@ public class FixtureServiceImpl implements FixtureService {
     public Page<Fixture> getFixturesToday(Status filter, Pageable pageable) {
         log.debug("getFixturesToday(filter: {}, pageable: {})...", filter, pageable);
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now), getToNow(now), filter, pageable);
+        return getFixturesByPeriod(getDayBegin(now), getDayEnd(now), filter, pageable);
     }
 
     @Override
@@ -157,7 +157,7 @@ public class FixtureServiceImpl implements FixtureService {
     public List<Fixture> getFixturesLastWeek() {
         log.debug("getFixturesLastWeek()...");
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now).minusDays(7), getToNow(now));
+        return getFixturesByPeriod(getDayBegin(now).minusDays(7), getDayEnd(now));
     }
 
     @Override
@@ -165,7 +165,7 @@ public class FixtureServiceImpl implements FixtureService {
     public Page<Fixture> getFixturesLastWeek(Pageable pageable) {
         log.debug("getFixturesLastWeek(pageable: {})...", pageable);
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now).minusDays(7), getToNow(now), pageable);
+        return getFixturesByPeriod(getDayBegin(now).minusDays(7), getDayEnd(now), pageable);
     }
 
     @Override
@@ -173,7 +173,7 @@ public class FixtureServiceImpl implements FixtureService {
     public List<Fixture> getFixturesLastWeek(Status filter) {
         log.debug("getFixturesLastWeek(filter: {})...", filter);
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now).minusDays(7), getToNow(now), filter);
+        return getFixturesByPeriod(getDayBegin(now).minusDays(7), getDayEnd(now), filter);
     }
 
     @Override
@@ -181,7 +181,7 @@ public class FixtureServiceImpl implements FixtureService {
     public Page<Fixture> getFixturesLastWeek(Status filter, Pageable pageable) {
         log.debug("getFixturesLastWeek(filter: {}, pageable: {})...", filter, pageable);
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now).minusDays(7), getToNow(now), filter, pageable);
+        return getFixturesByPeriod(getDayBegin(now).minusDays(7), getDayEnd(now), filter, pageable);
     }
 
     @Override
@@ -189,7 +189,7 @@ public class FixtureServiceImpl implements FixtureService {
     public List<Fixture> getFixturesNextWeek() {
         log.debug("getFixturesNextWeek()...");
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now), getToNow(now).plusDays(7));
+        return getFixturesByPeriod(getDayBegin(now), getDayEnd(now).plusDays(7));
     }
 
     @Override
@@ -197,7 +197,7 @@ public class FixtureServiceImpl implements FixtureService {
     public Page<Fixture> getFixturesNextWeek(Pageable pageable) {
         log.debug("getFixturesNextWeek(pageable: {})...", pageable);
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now), getToNow(now).plusDays(7), pageable);
+        return getFixturesByPeriod(getDayBegin(now), getDayEnd(now).plusDays(7), pageable);
     }
 
     @Override
@@ -205,7 +205,7 @@ public class FixtureServiceImpl implements FixtureService {
     public List<Fixture> getFixturesNextWeek(Status filter) {
         log.debug("getFixturesNextWeek(filter: {})...", filter);
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now), getToNow(now).plusDays(7), filter);
+        return getFixturesByPeriod(getDayBegin(now), getDayEnd(now).plusDays(7), filter);
     }
 
     @Override
@@ -213,7 +213,7 @@ public class FixtureServiceImpl implements FixtureService {
     public Page<Fixture> getFixturesNextWeek(Status filter, Pageable pageable) {
         log.debug("getFixturesNextWeek(filter: {}, pageable: {})...", filter, pageable);
         final LocalDate now = LocalDate.now();
-        return getFixturesByPeriod(getFromNow(now), getToNow(now).plusDays(7), filter, pageable);
+        return getFixturesByPeriod(getDayBegin(now), getDayEnd(now).plusDays(7), filter, pageable);
     }
 
     @Override

--- a/src/main/java/ru/kappers/service/impl/FixtureServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/FixtureServiceImpl.java
@@ -2,6 +2,8 @@ package ru.kappers.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.kappers.model.Fixture;
@@ -63,9 +65,23 @@ public class FixtureServiceImpl implements FixtureService {
 
     @Override
     @Transactional(readOnly = true)
+    public Page<Fixture> getAll(Pageable pageable) {
+        log.debug("getAll(pageable: {})...", pageable);
+        return repository.findAll(pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<Fixture> getFixturesByPeriod(Timestamp from, Timestamp to) {
         log.debug("getFixturesByPeriod(from: {}, to: {})...", from, to);
         return repository.getFixturesByPeriod(from, to);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Fixture> getFixturesByPeriod(Timestamp from, Timestamp to, Pageable pageable) {
+        log.debug("getFixturesByPeriod(from: {}, to: {}, pageable: {})...", from, to, pageable);
+        return repository.getFixturesByPeriod(from, to, pageable);
     }
 
     @Override
@@ -77,9 +93,23 @@ public class FixtureServiceImpl implements FixtureService {
 
     @Override
     @Transactional(readOnly = true)
+    public Page<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Pageable pageable) {
+        log.debug("getFixturesByPeriod(from: {}, to: {}, pageable: {})...", from, to, pageable);
+        return getFixturesByPeriod(Timestamp.valueOf(from), Timestamp.valueOf(to), pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Status filter) {
         log.debug("getFixturesByPeriod(from: {}, to: {}, filter: {})...", from, to, filter);
         return repository.getFixturesByPeriod(Timestamp.valueOf(from), Timestamp.valueOf(to), filter);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Fixture> getFixturesByPeriod(LocalDateTime from, LocalDateTime to, Status filter, Pageable pageable) {
+        log.debug("getFixturesByPeriod(from: {}, to: {}, filter: {}, pageable: {})...", from, to, filter, pageable);
+        return repository.getFixturesByPeriod(Timestamp.valueOf(from), Timestamp.valueOf(to), filter, pageable);
     }
 
     protected LocalDateTime getFromNow(LocalDate now) {
@@ -100,10 +130,26 @@ public class FixtureServiceImpl implements FixtureService {
 
     @Override
     @Transactional(readOnly = true)
+    public Page<Fixture> getFixturesToday(Pageable pageable) {
+        log.debug("getFixturesToday(pageable)...");
+        final LocalDate now = LocalDate.now();
+        return getFixturesByPeriod(getFromNow(now), getToNow(now), pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<Fixture> getFixturesToday(Status filter) {
         log.debug("getFixturesToday(filter: {})...", filter);
         final LocalDate now = LocalDate.now();
         return getFixturesByPeriod(getFromNow(now), getToNow(now), filter);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Fixture> getFixturesToday(Status filter, Pageable pageable) {
+        log.debug("getFixturesToday(filter: {}, pageable: {})...", filter, pageable);
+        final LocalDate now = LocalDate.now();
+        return getFixturesByPeriod(getFromNow(now), getToNow(now), filter, pageable);
     }
 
     @Override
@@ -116,10 +162,26 @@ public class FixtureServiceImpl implements FixtureService {
 
     @Override
     @Transactional(readOnly = true)
+    public Page<Fixture> getFixturesLastWeek(Pageable pageable) {
+        log.debug("getFixturesLastWeek(pageable: {})...", pageable);
+        final LocalDate now = LocalDate.now();
+        return getFixturesByPeriod(getFromNow(now).minusDays(7), getToNow(now), pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<Fixture> getFixturesLastWeek(Status filter) {
         log.debug("getFixturesLastWeek(filter: {})...", filter);
         final LocalDate now = LocalDate.now();
         return getFixturesByPeriod(getFromNow(now).minusDays(7), getToNow(now), filter);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Fixture> getFixturesLastWeek(Status filter, Pageable pageable) {
+        log.debug("getFixturesLastWeek(filter: {}, pageable: {})...", filter, pageable);
+        final LocalDate now = LocalDate.now();
+        return getFixturesByPeriod(getFromNow(now).minusDays(7), getToNow(now), filter, pageable);
     }
 
     @Override
@@ -132,10 +194,26 @@ public class FixtureServiceImpl implements FixtureService {
 
     @Override
     @Transactional(readOnly = true)
+    public Page<Fixture> getFixturesNextWeek(Pageable pageable) {
+        log.debug("getFixturesNextWeek(pageable: {})...", pageable);
+        final LocalDate now = LocalDate.now();
+        return getFixturesByPeriod(getFromNow(now), getToNow(now).plusDays(7), pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<Fixture> getFixturesNextWeek(Status filter) {
         log.debug("getFixturesNextWeek(filter: {})...", filter);
         final LocalDate now = LocalDate.now();
         return getFixturesByPeriod(getFromNow(now), getToNow(now).plusDays(7), filter);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Fixture> getFixturesNextWeek(Status filter, Pageable pageable) {
+        log.debug("getFixturesNextWeek(filter: {}, pageable: {})...", filter, pageable);
+        final LocalDate now = LocalDate.now();
+        return getFixturesByPeriod(getFromNow(now), getToNow(now).plusDays(7), filter, pageable);
     }
 
     @Override

--- a/src/main/java/ru/kappers/util/DateTimeUtil.java
+++ b/src/main/java/ru/kappers/util/DateTimeUtil.java
@@ -15,8 +15,10 @@ import java.time.format.DateTimeFormatter;
 @Slf4j
 public final class DateTimeUtil {
 
+	/** миллисекунд в часе */
+	public static final int MILLISECONDS_IN_HOUR = 3600 * 1000;
 	/** миллисекунд в сутках */
-	public static final int MILLISECONDS_IN_DAY = 24 * 3600 * 1000;
+	public static final int MILLISECONDS_IN_DAY = 24 * MILLISECONDS_IN_HOUR;
 	/** миллисекунд в неделе */
 	public static final int MILLISECONDS_IN_WEEK = MILLISECONDS_IN_DAY * 7;
 

--- a/src/main/resources/public/ui/view/nextweek/list.html
+++ b/src/main/resources/public/ui/view/nextweek/list.html
@@ -59,7 +59,7 @@
         </tr>
         </thead>
         <tbody>
-        <tr ng-repeat="fixture in fixtures | filter:search">
+        <tr ng-repeat="fixture in fixtures.content | filter:search">
             <!--<th scope="row">
                 <input for="{{employee.id}}" type="checkbox" ng-model="selection.ids[employee.id]" name="group" id="check_{{employee.id}}" />
             </th>-->

--- a/src/main/resources/public/ui/view/nextweek/list.html
+++ b/src/main/resources/public/ui/view/nextweek/list.html
@@ -59,7 +59,9 @@
         </tr>
         </thead>
         <tbody>
-        <tr ng-repeat="fixture in fixtures.content | filter:search">
+<!--        if has pagenation -->
+<!--        <tr ng-repeat="fixture in fixtures.content | filter:search">-->
+        <tr ng-repeat="fixture in fixtures | filter:search">
             <!--<th scope="row">
                 <input for="{{employee.id}}" type="checkbox" ng-model="selection.ids[employee.id]" name="group" id="check_{{employee.id}}" />
             </th>-->


### PR DESCRIPTION
- Доработан DateTimeUtil, добавлена константа для миллисекунд в часе
- Доработан репозиторий для спортивных событий, исправлены старые запросы, добавлены новые с паджинацией, и те и другие теперь включают границы периода в выборку
- Доработаны интерфейс и реализация сервиса спортивных событий, для методов выборки данных добавлены перегруженные версии с паджинацией
- Рефакторинг FixtureServiceImpl, переименованы 2 защищенных метода
- Доработаны интеграционные тесты FixtureServiceImplTest для сервиса спортивных событий.
- Тестовая доработка отображения Предстоящих событий с ограничением выборки через паджинацию. Тестовый URL запроса: http://localhost:8080/rest/fixture/nextweek?page=1&size=30&sort=eventDate
- Пока закомментировал паджинацию в контроллере и web UI