### PR TITLE
Joda Money integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,23 +24,86 @@
         <java.version>1.8</java.version>
     </properties>
 
+<!-- Для централизованного управления зависимостями их версии указываем по возможности только здесь, как и исключения в них -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.0</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/com.mashape.unirest/unirest-java -->
+            <dependency>
+                <groupId>com.mashape.unirest</groupId>
+                <artifactId>unirest-java</artifactId>
+                <version>1.4.9</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>2.8.5</version>
+            </dependency>
+
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.17</version>
+            </dependency>
+            <dependency>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-core</artifactId>
+                <version>5.0.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.dbunit</groupId>
+                <artifactId>dbunit</artifactId>
+                <version>2.5.0</version>
+                <type>jar</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.springtestdbunit</groupId>
+                <artifactId>spring-test-dbunit</artifactId>
+                <version>1.2.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.DECENTfoundation</groupId>
+                <artifactId>DCoreKt-SDK</artifactId>
+                <version>1.2.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.joda</groupId>
+                <artifactId>joda-money</artifactId>
+                <version>1.0.1</version>
+            </dependency>
+<!--
+            <dependency>
+                <groupId>org.jadira.usertype</groupId>
+                <artifactId>usertype.core</artifactId>
+&lt;!&ndash;                <version>7.0.0.CR1</version>&ndash;&gt;
+                <version>7.0.0.CR2-SNAPSHOT</version>
+            </dependency>
+-->
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.mashape.unirest/unirest-java -->
         <dependency>
             <groupId>com.mashape.unirest</groupId>
             <artifactId>unirest-java</artifactId>
-            <version>1.4.9</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
         </dependency>
 
         <dependency>
@@ -133,12 +196,10 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>5.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -148,21 +209,26 @@
         <dependency>
             <groupId>org.dbunit</groupId>
             <artifactId>dbunit</artifactId>
-            <version>2.5.0</version>
-            <type>jar</type>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.springtestdbunit</groupId>
             <artifactId>spring-test-dbunit</artifactId>
-            <version>1.2.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.DECENTfoundation</groupId>
             <artifactId>DCoreKt-SDK</artifactId>
-            <version>1.2.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.joda</groupId>
+            <artifactId>joda-money</artifactId>
+        </dependency>
+<!--
+        <dependency>
+            <groupId>org.jadira.usertype</groupId>
+            <artifactId>usertype.core</artifactId>
+        </dependency>
+-->
     </dependencies>
 
     <repositories>

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/joda/AbstractSingleColumnMoneyUserType.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/joda/AbstractSingleColumnMoneyUserType.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.joda;
+
+import java.util.Properties;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.usertype.ParameterizedType;
+import org.jadira.usertype.moneyandcurrency.joda.util.CurrencyUnitConfigured;
+import org.jadira.usertype.spi.shared.AbstractSingleColumnUserType;
+import org.jadira.usertype.spi.shared.ColumnMapper;
+import org.jadira.usertype.spi.shared.ConfigurationHelper;
+import org.jadira.usertype.spi.shared.IntegratorConfiguredType;
+import org.jadira.usertype.spi.utils.lang.ConcurrentHashMapBackedProperties;
+import org.joda.money.CurrencyUnit;
+
+/**
+ * Base class for money types that do not map a currency column using a configured currency instead.
+ */
+public abstract class AbstractSingleColumnMoneyUserType<T, J, C extends ColumnMapper<T, J>> extends AbstractSingleColumnUserType<T, J, C> implements ParameterizedType, IntegratorConfiguredType {
+
+    private static final long serialVersionUID = 8244061728586173961L;
+
+    private Properties parameterValues;
+
+    private CurrencyUnit currencyUnit;
+
+    @Override
+    public void setParameterValues(Properties parameters) {
+        this.parameterValues = new ConcurrentHashMapBackedProperties(parameters);
+    }
+
+    protected Properties getParameterValues() {
+        return parameterValues;
+    }
+
+    @Override
+    public void applyConfiguration(SessionFactory sessionFactory) {
+
+        CurrencyUnitConfigured columnMapper = (CurrencyUnitConfigured) getColumnMapper();
+        if (currencyUnit == null) {
+
+            String currencyString = null;
+            if (parameterValues != null) {
+                currencyString = parameterValues.getProperty("currencyCode");
+            }
+            if (currencyString == null) {
+                currencyString = ConfigurationHelper.getProperty("currencyCode");
+            }
+            if (currencyString != null) {
+
+                currencyUnit = CurrencyUnit.of(currencyString);
+            } else {
+                throw new IllegalStateException(getClass().getSimpleName() + " requires currencyCode to be defined as a parameter, or the jadira.usertype.currencyCode Hibernate property to be defined");
+            }
+        }
+        columnMapper.setCurrencyUnit(currencyUnit);
+    }
+}

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentBigMoneyAmount.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentBigMoneyAmount.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.joda;
+
+import java.math.BigDecimal;
+
+import org.hibernate.usertype.ParameterizedType;
+import org.jadira.usertype.moneyandcurrency.joda.columnmapper.BigDecimalColumnBigMoneyMapper;
+import org.jadira.usertype.spi.shared.IntegratorConfiguredType;
+import org.joda.money.BigMoney;
+
+/**
+ * Maps {@link BigMoney} to and from a BigDecimal column.
+ */
+public class PersistentBigMoneyAmount extends AbstractSingleColumnMoneyUserType<BigMoney, BigDecimal, BigDecimalColumnBigMoneyMapper> implements ParameterizedType, IntegratorConfiguredType {
+
+    private static final long serialVersionUID = 486431542623762640L;
+}

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentCurrencyUnit.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentCurrencyUnit.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.joda;
+
+import org.jadira.usertype.moneyandcurrency.joda.columnmapper.StringColumnCurrencyUnitMapper;
+import org.jadira.usertype.spi.shared.AbstractSingleColumnUserType;
+import org.joda.money.CurrencyUnit;
+
+/**
+ * Maps a {@link CurrencyUnit} to and from String for Hibernate.
+ */
+public class PersistentCurrencyUnit extends AbstractSingleColumnUserType<CurrencyUnit, String, StringColumnCurrencyUnitMapper> {
+
+    private static final long serialVersionUID = 5653012946771904484L;
+}

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentMoneyAmount.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentMoneyAmount.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.joda;
+
+import java.math.BigDecimal;
+
+import org.hibernate.usertype.ParameterizedType;
+import org.jadira.usertype.moneyandcurrency.joda.columnmapper.BigDecimalColumnMoneyMapper;
+import org.jadira.usertype.spi.shared.IntegratorConfiguredType;
+import org.joda.money.Money;
+
+/**
+ * Maps {@link Money} to and from a BigDecimal column.
+ */
+public class PersistentMoneyAmount extends AbstractSingleColumnMoneyUserType<Money, BigDecimal, BigDecimalColumnMoneyMapper> implements ParameterizedType, IntegratorConfiguredType {
+
+    private static final long serialVersionUID = 486431542623762640L;
+}

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentMoneyAmountAndCurrency.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/joda/PersistentMoneyAmountAndCurrency.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.joda;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.jadira.usertype.moneyandcurrency.joda.columnmapper.StringColumnCurrencyUnitMapper;
+import org.jadira.usertype.moneyandcurrency.legacyjdk.columnmapper.BigDecimalBigDecimalColumnMapper;
+import org.jadira.usertype.spi.shared.AbstractMultiColumnUserType;
+import org.jadira.usertype.spi.shared.ColumnMapper;
+import org.joda.money.CurrencyUnit;
+import org.joda.money.Money;
+
+/**
+ * Persists the decimal amount and currency from a Money instance
+ */
+public class PersistentMoneyAmountAndCurrency extends AbstractMultiColumnUserType<Money> {
+
+    private static final long serialVersionUID = 3735995469031558183L;
+
+    private static final ColumnMapper<?, ?>[] COLUMN_MAPPERS = new ColumnMapper<?, ?>[] { new StringColumnCurrencyUnitMapper(), new BigDecimalBigDecimalColumnMapper() };
+
+    private static final String[] PROPERTY_NAMES = new String[]{ "currencyUnit", "amount" };
+
+    private RoundingMode roundingMode;
+
+    public PersistentMoneyAmountAndCurrency() {
+        this(RoundingMode.HALF_UP);
+    }
+
+    public PersistentMoneyAmountAndCurrency(RoundingMode roundingMode) {
+        super();
+        this.roundingMode = roundingMode;
+    }
+
+    @Override
+    protected ColumnMapper<?, ?>[] getColumnMappers() {
+        return COLUMN_MAPPERS;
+    }
+
+    @Override
+    protected Money fromConvertedColumns(Object[] convertedColumns) {
+
+        CurrencyUnit currencyUnitPart = (CurrencyUnit) convertedColumns[0];
+        BigDecimal amountPart = (BigDecimal) convertedColumns[1];
+        Money money = Money.of(currencyUnitPart, amountPart, roundingMode);
+
+        return money;
+    }
+
+    @Override
+    protected Object[] toConvertedColumns(Money value) {
+
+        return new Object[] { value.getCurrencyUnit(), value.getAmount() };
+    }
+
+    @Override
+    public String[] getPropertyNames() {
+        return PROPERTY_NAMES;
+    }
+}

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/BigDecimalColumnBigMoneyMapper.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/BigDecimalColumnBigMoneyMapper.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.joda.columnmapper;
+
+import java.math.BigDecimal;
+
+import org.jadira.usertype.moneyandcurrency.joda.util.CurrencyUnitConfigured;
+import org.jadira.usertype.spi.shared.AbstractBigDecimalColumnMapper;
+import org.joda.money.BigMoney;
+import org.joda.money.CurrencyUnit;
+
+public class BigDecimalColumnBigMoneyMapper extends AbstractBigDecimalColumnMapper<BigMoney> implements CurrencyUnitConfigured {
+
+    private static final long serialVersionUID = 4205713919952452881L;
+
+    private CurrencyUnit currencyUnit;
+
+    @Override
+    public BigMoney fromNonNullValue(BigDecimal val) {
+        return BigMoney.of(currencyUnit, val);
+    }
+
+    @Override
+    public BigDecimal toNonNullValue(BigMoney value) {
+        if (!currencyUnit.equals(value.getCurrencyUnit())) {
+            throw new IllegalStateException("Expected currency " + currencyUnit.getCode() + " but was " + value.getCurrencyUnit());
+        }
+        return BigMoney.of(value).getAmount();
+    }
+
+    @Override
+    public BigMoney fromNonNullString(String s) {
+        return BigMoney.parse(s);
+    }
+
+    @Override
+    public String toNonNullString(BigMoney value) {
+        return value.toString();
+    }
+
+    @Override
+    public void setCurrencyUnit(CurrencyUnit currencyUnit) {
+        this.currencyUnit = currencyUnit;
+    }
+}

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/BigDecimalColumnMoneyMapper.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/BigDecimalColumnMoneyMapper.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.joda.columnmapper;
+
+import java.math.BigDecimal;
+
+import org.jadira.usertype.moneyandcurrency.joda.util.CurrencyUnitConfigured;
+import org.jadira.usertype.spi.shared.AbstractBigDecimalColumnMapper;
+import org.joda.money.CurrencyUnit;
+import org.joda.money.Money;
+
+public class BigDecimalColumnMoneyMapper extends AbstractBigDecimalColumnMapper<Money> implements CurrencyUnitConfigured {
+
+    private static final long serialVersionUID = 4205713919952452881L;
+
+    private CurrencyUnit currencyUnit;
+
+    @Override
+    public Money fromNonNullValue(BigDecimal val) {
+        return Money.of(currencyUnit, val);
+    }
+
+    @Override
+    public BigDecimal toNonNullValue(Money value) {
+        if (!currencyUnit.equals(value.getCurrencyUnit())) {
+            throw new IllegalStateException("Expected currency " + currencyUnit.getCode() + " but was " + value.getCurrencyUnit());
+        }
+        return value.getAmount();
+    }
+
+    @Override
+    public Money fromNonNullString(String s) {
+        return Money.parse(s);
+    }
+
+    @Override
+    public String toNonNullString(Money value) {
+        return value.toString();
+    }
+
+    @Override
+    public void setCurrencyUnit(CurrencyUnit currencyUnit) {
+        this.currencyUnit = currencyUnit;
+    }
+}

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/StringColumnCurrencyUnitMapper.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/joda/columnmapper/StringColumnCurrencyUnitMapper.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.joda.columnmapper;
+
+import org.jadira.usertype.spi.shared.AbstractStringColumnMapper;
+import org.joda.money.CurrencyUnit;
+
+public class StringColumnCurrencyUnitMapper extends AbstractStringColumnMapper<CurrencyUnit> {
+
+    private static final long serialVersionUID = 4205713919952452881L;
+
+    @Override
+    public CurrencyUnit fromNonNullValue(String s) {
+        return CurrencyUnit.of(s);
+    }
+
+    @Override
+    public String toNonNullValue(CurrencyUnit value) {
+        return value.getCode();
+    }
+}

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/joda/integrator/UserTypeJodaMoneyHibernateIntegrator.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/joda/integrator/UserTypeJodaMoneyHibernateIntegrator.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.joda.integrator;
+
+import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.usertype.CompositeUserType;
+import org.hibernate.usertype.UserType;
+import org.jadira.usertype.moneyandcurrency.joda.PersistentBigMoneyAmount;
+import org.jadira.usertype.moneyandcurrency.joda.PersistentCurrencyUnit;
+import org.jadira.usertype.moneyandcurrency.joda.PersistentMoneyAmount;
+import org.jadira.usertype.spi.shared.AbstractUserTypeHibernateIntegrator;
+import org.jadira.usertype.spi.utils.reflection.ClassLoaderUtils;
+
+public class UserTypeJodaMoneyHibernateIntegrator extends AbstractUserTypeHibernateIntegrator implements Integrator {
+
+    private static UserType[] userTypes;
+    private static final CompositeUserType[] COMPOSITE_USER_TYPES = new CompositeUserType[]{};
+
+    static {
+
+        boolean found = false;
+
+        try {
+            Class.forName("org.joda.money.BigMoney", false, ClassLoaderUtils.getClassLoader());
+            found = true;
+        } catch (ClassNotFoundException e) {
+        }
+
+        try {
+            Class.forName("org.joda.money.BigMoney");
+            found = true;
+        } catch (ClassNotFoundException e) {
+        }
+
+        if (found) {
+
+            userTypes = new UserType[]{
+                    new PersistentBigMoneyAmount(),
+                    new PersistentMoneyAmount(),
+                    new PersistentCurrencyUnit()
+            };
+
+        } else {
+            userTypes = new UserType[]{};
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected CompositeUserType[] getCompositeUserTypes() {
+        return COMPOSITE_USER_TYPES;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected UserType[] getUserTypes() {
+        return userTypes;
+    }
+}

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/joda/util/CurrencyUnitConfigured.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/joda/util/CurrencyUnitConfigured.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.joda.util;
+
+import org.joda.money.CurrencyUnit;
+
+public interface CurrencyUnitConfigured {
+
+    void setCurrencyUnit(CurrencyUnit currencyUnit);
+}

--- a/src/main/java/org/jadira/usertype/moneyandcurrency/legacyjdk/columnmapper/BigDecimalBigDecimalColumnMapper.java
+++ b/src/main/java/org/jadira/usertype/moneyandcurrency/legacyjdk/columnmapper/BigDecimalBigDecimalColumnMapper.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2010, 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.moneyandcurrency.legacyjdk.columnmapper;
+
+import java.math.BigDecimal;
+
+import org.jadira.usertype.spi.shared.AbstractBigDecimalColumnMapper;
+
+public class BigDecimalBigDecimalColumnMapper extends AbstractBigDecimalColumnMapper<BigDecimal> {
+
+    private static final long serialVersionUID = -9337890199015880L;
+
+    @Override
+    public BigDecimal fromNonNullValue(BigDecimal value) {
+        return value;
+    }
+
+    @Override
+    public BigDecimal fromNonNullString(String s) {
+        return new BigDecimal(s);
+    }
+
+    @Override
+    public BigDecimal toNonNullValue(BigDecimal value) {
+        return value;
+    }
+
+    @Override
+    public String toNonNullString(BigDecimal value) {
+        return value.toString();
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/AbstractBigDecimalColumnMapper.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/AbstractBigDecimalColumnMapper.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import java.math.BigDecimal;
+import java.sql.Types;
+
+import org.hibernate.type.BigDecimalType;
+import org.hibernate.type.StandardBasicTypes;
+
+public abstract class AbstractBigDecimalColumnMapper<T> extends AbstractColumnMapper<T, BigDecimal> {
+
+    private static final long serialVersionUID = 1702998875351962961L;
+
+    @Override
+    public final int getSqlType() {
+        return Types.NUMERIC;
+    }
+
+    @Override
+    public final BigDecimalType getHibernateType() {
+        return StandardBasicTypes.BIG_DECIMAL;
+    }
+
+    @Override
+    public abstract T fromNonNullValue(BigDecimal value);
+
+    @Override
+    public abstract T fromNonNullString(String s);
+
+    @Override
+    public abstract BigDecimal toNonNullValue(T value);
+
+    @Override
+    public abstract String toNonNullString(T value);
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/AbstractColumnMapper.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/AbstractColumnMapper.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2010, 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import java.io.Serializable;
+
+import org.jadira.usertype.spi.utils.reflection.TypeHelper;
+
+
+public abstract class AbstractColumnMapper<T, J> implements Serializable, ColumnMapper<T, J> {
+
+    private static final long serialVersionUID = 8169781475234949904L;
+
+    /* (non-Javadoc)
+     * @see org.jadira.usertype.dateandtime.shared.spi.ColumnMapper#returnedClass()
+     */
+    @Override
+    public final Class<T> returnedClass() {
+        @SuppressWarnings("unchecked")Class<T> result = (Class<T>) TypeHelper.getTypeArguments(AbstractColumnMapper.class, getClass()).get(0);
+        return result;
+    }
+
+    /* (non-Javadoc)
+     * @see org.jadira.usertype.dateandtime.shared.spi.ColumnMapper#jdbcClass()
+     */
+    @Override
+    public final Class<J> jdbcClass() {
+        @SuppressWarnings("unchecked")
+        Class<J> result = (Class<J>) TypeHelper.getTypeArguments(ColumnMapper.class, getClass()).get(1);
+        return result;
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/AbstractMultiColumnUserType.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/AbstractMultiColumnUserType.java
@@ -1,0 +1,224 @@
+/*
+ *  Copyright 2010, 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import static org.jadira.usertype.spi.utils.reflection.ArrayUtils.copyOf;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.Type;
+import org.hibernate.usertype.CompositeUserType;
+import org.jadira.usertype.spi.utils.reflection.TypeHelper;
+
+public abstract class AbstractMultiColumnUserType<T> extends AbstractUserType implements CompositeUserType, Serializable {
+
+    private static final long serialVersionUID = -8258683760413283329L;
+
+    private int[] sqlTypes;
+
+    private Type[] hibernateTypes;
+
+    /* DefaultPropertyNames is currently not being used */
+    private String[] defaultPropertyNames;
+
+    public AbstractMultiColumnUserType() {
+
+        initialise();
+    }
+
+    protected final void initialise() {
+
+        initialiseSqlTypes();
+        initialiseHibernateTypes();
+        initialiseDefaultPropertyNames();
+    }
+
+    private void initialiseDefaultPropertyNames() {
+        Map<String, Integer> nameCount = new HashMap<String, Integer>();
+
+        defaultPropertyNames = new String[getColumnMappers().length];
+        for (int i = 0; i < defaultPropertyNames.length; i++) {
+            String className = hibernateTypes[i].getClass().getSimpleName();
+            if (className.endsWith("Type")) {
+                className = className.substring(0, className.length() - 4);
+            }
+
+            String name = className.toLowerCase();
+            final Integer count;
+            if (nameCount.containsKey(name)) {
+                Integer oldCount = nameCount.get(name);
+                count = oldCount.intValue() + 1;
+                defaultPropertyNames[i] = name + count;
+            } else {
+                count = 1;
+                defaultPropertyNames[i] = name;
+            }
+            nameCount.put(name, count);
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private void initialiseHibernateTypes() {
+        hibernateTypes = new Type[getColumnMappers().length];
+        for (int i = 0; i < hibernateTypes.length; i++) {
+            hibernateTypes[i] = new ColumnMapperSingleColumnTypeAdapter(getColumnMappers()[i]);
+        }
+    }
+
+    private void initialiseSqlTypes() {
+        sqlTypes = new int[getColumnMappers().length];
+        for (int i = 0; i < sqlTypes.length; i++) {
+            sqlTypes[i] = getColumnMappers()[i].getSqlType();
+        }
+    }
+
+    public int[] sqlTypes() {
+        return copyOf(sqlTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<T> returnedClass() {
+        return (Class<T>) TypeHelper.getTypeArguments(AbstractMultiColumnUserType.class, getClass()).get(0);
+    }
+
+    protected abstract ColumnMapper<?, ?>[] getColumnMappers();
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public T nullSafeGet(ResultSet resultSet, String[] strings, SharedSessionContractImplementor session, Object object) throws SQLException {
+
+        beforeNullSafeOperation(session);
+
+        final SharedSessionContractImplementor mySession = doWrapSession(session);
+
+        try {
+            Object[] convertedColumns = new Object[getColumnMappers().length];
+
+            for (int getIndex = 0; getIndex < getColumnMappers().length; getIndex++) {
+                ColumnMapper nextMapper = getColumnMappers()[getIndex];
+
+                final Object converted = nextMapper.getHibernateType().nullSafeGet(resultSet, strings[getIndex], mySession, object);
+
+                if (converted != null) {
+                    convertedColumns[getIndex] = nextMapper.fromNonNullValue(converted);
+                }
+            }
+
+            for (int i = 0; i < convertedColumns.length; i++) {
+                if (convertedColumns[i] != null) {
+                    return fromConvertedColumns(convertedColumns);
+                }
+            }
+
+            return null;
+
+        } finally {
+            afterNullSafeOperation(session);
+        }
+    }
+
+    protected abstract T fromConvertedColumns(Object[] convertedColumns);
+
+    protected abstract Object[] toConvertedColumns(T value);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void nullSafeSet(PreparedStatement preparedStatement, Object value, int index, SharedSessionContractImplementor session) throws SQLException {
+
+        beforeNullSafeOperation(session);
+
+        final SharedSessionContractImplementor mySession = doWrapSession(session);
+
+        try {
+            final Object[] valuesToSet = new Object[getColumnMappers().length];
+
+            if (value != null) {
+
+                final T myValue = (T) value;
+                Object[] convertedColumns = toConvertedColumns(myValue);
+
+                for (int cIdx = 0; cIdx < valuesToSet.length; cIdx++) {
+
+                    @SuppressWarnings("rawtypes") ColumnMapper nextMapper = getColumnMappers()[cIdx];
+                    valuesToSet[cIdx] = nextMapper.toNonNullValue(convertedColumns[cIdx]);
+                }
+            }
+
+            for (int setIndex = 0; setIndex < valuesToSet.length; setIndex++) {
+
+                @SuppressWarnings("rawtypes") ColumnMapper nextMapper = getColumnMappers()[setIndex];
+
+                // TODO Still need to work out where an adjuster will be injected
+                nextMapper.getHibernateType().nullSafeSet(preparedStatement, valuesToSet[setIndex], index + setIndex, mySession);
+            }
+
+        } finally {
+            afterNullSafeOperation(session);
+        }
+    }
+
+    protected SharedSessionContractImplementor doWrapSession(SharedSessionContractImplementor session) {
+        return session;
+    }
+
+    @Override
+    public String[] getPropertyNames() {
+        return defaultPropertyNames;
+    }
+
+    @Override
+    public Type[] getPropertyTypes() {
+        return copyOf(hibernateTypes);
+    }
+
+    @Override
+    public Object getPropertyValue(Object component, int property) throws HibernateException {
+
+        if (!returnedClass().isAssignableFrom(component.getClass())) {
+            throw new HibernateException("getPropertyValue called with incorrect class: {" + component.getClass() + "}");
+        }
+        @SuppressWarnings("unchecked") Object[] cols = toConvertedColumns((T) component);
+        return cols[property];
+    }
+
+    @Override
+    public void setPropertyValue(Object component, int property, Object value) throws HibernateException {
+        throw new HibernateException("Called setPropertyValue on an immutable type {" + component.getClass() + "}");
+    }
+
+    @Override
+    public Serializable disassemble(Object value, SharedSessionContractImplementor session) throws HibernateException {
+        return super.disassemble(value);
+    }
+
+    @Override
+    public Object assemble(Serializable cached, SharedSessionContractImplementor session, Object owner) throws HibernateException {
+        return super.assemble(cached, owner);
+    }
+
+    @Override
+    public Object replace(Object original, Object target, SharedSessionContractImplementor session, Object owner) throws HibernateException {
+        return super.replace(original, target, owner);
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/AbstractSingleColumnUserType.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/AbstractSingleColumnUserType.java
@@ -1,0 +1,140 @@
+/*
+ *  Copyright 2010, 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import static org.jadira.usertype.spi.utils.reflection.ArrayUtils.copyOf;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.usertype.EnhancedUserType;
+import org.jadira.usertype.spi.utils.reflection.TypeHelper;
+
+public abstract class AbstractSingleColumnUserType<T, J, C extends ColumnMapper<T, J>> extends AbstractUserType implements EnhancedUserType, Serializable {
+
+    private static final long serialVersionUID = -8258683760413283329L;
+
+    private final C columnMapper;
+    private final int[] sqlTypes;
+
+    @SuppressWarnings("unchecked")
+    public AbstractSingleColumnUserType() {
+
+        try {
+            columnMapper = (C) TypeHelper.getTypeArguments(AbstractSingleColumnUserType.class, getClass()).get(2).newInstance();
+        } catch (InstantiationException ex) {
+            throw new HibernateException("Could not initialise column mapper for " + getClass(), ex);
+        } catch (IllegalAccessException ex) {
+            throw new HibernateException("Could not access column mapper for " + getClass(), ex);
+        }
+        sqlTypes = new int[] { getColumnMapper().getSqlType() };
+    }
+
+    public final C getColumnMapper() {
+        return columnMapper;
+    }
+
+    @Override
+    public Class<T> returnedClass() {
+        return getColumnMapper().returnedClass();
+    }
+
+    @Override
+    public final int[] sqlTypes() {
+        return copyOf(sqlTypes);
+    }
+
+    @Override
+    public T nullSafeGet(ResultSet resultSet, String[] strings, SharedSessionContractImplementor session, Object object) throws SQLException {
+
+        beforeNullSafeOperation(session);
+
+        final SharedSessionContractImplementor mySession = doWrapSession(session);
+
+        try {
+            J converted = doNullSafeGet(resultSet, strings, mySession, object);
+
+            if (converted == null) {
+                return null;
+            }
+
+            return getColumnMapper().fromNonNullValue(converted);
+
+        } finally {
+            afterNullSafeOperation(session);
+        }
+    }
+
+    protected J doNullSafeGet(ResultSet resultSet, String[] strings, SharedSessionContractImplementor session, Object object) throws SQLException {
+        @SuppressWarnings("unchecked")
+        final J converted = (J) getColumnMapper().getHibernateType().nullSafeGet(resultSet, strings[0], session, object);
+        return converted;
+    }
+
+    @Override
+    public void nullSafeSet(PreparedStatement preparedStatement, Object value, int index, SharedSessionContractImplementor session) throws SQLException {
+
+        beforeNullSafeOperation(session);
+
+        final SharedSessionContractImplementor mySession = doWrapSession(session);
+
+        try {
+            final J transformedValue;
+            if (value == null) {
+                transformedValue = null;
+            } else {
+                @SuppressWarnings("unchecked") T myValue = (T) value;
+                transformedValue = getColumnMapper().toNonNullValue(myValue);
+            }
+
+            doNullSafeSet(preparedStatement, transformedValue, index, mySession);
+
+        } finally {
+            afterNullSafeOperation(session);
+        }
+    }
+
+    protected void doNullSafeSet(PreparedStatement preparedStatement, J transformedValue, int index, SharedSessionContractImplementor session) throws SQLException {
+        getColumnMapper().getHibernateType().nullSafeSet(preparedStatement, transformedValue, index, session);
+    }
+
+    @Override
+    public String objectToSQLString(Object object) {
+        @SuppressWarnings("unchecked") final T myObject = (T) object;
+        J convertedObject = myObject == null ? null : getColumnMapper().toNonNullValue(myObject);
+
+        return getColumnMapper().getHibernateType().toString(convertedObject);
+    }
+
+    @Override
+    public String toXMLString(Object object) {
+        @SuppressWarnings("unchecked") final T myObject = (T) object;
+        return getColumnMapper().toNonNullString(myObject);
+    }
+
+    @Override
+    public T fromXMLString(String string) {
+        return getColumnMapper().fromNonNullString(string);
+    }
+
+    protected SharedSessionContractImplementor doWrapSession(SharedSessionContractImplementor session) {
+        return session;
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/AbstractStringColumnMapper.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/AbstractStringColumnMapper.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2010, 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import java.sql.Types;
+
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.StringType;
+
+public abstract class AbstractStringColumnMapper<T> extends AbstractColumnMapper<T, String> {
+
+    private static final long serialVersionUID = 790854698317453823L;
+
+    @Override
+    public final int getSqlType() {
+        return Types.VARCHAR;
+    }
+
+    @Override
+    public final StringType getHibernateType() {
+        return StandardBasicTypes.STRING;
+    }
+
+    @Override
+    public abstract T fromNonNullValue(String s);
+
+    @Override
+    public final T fromNonNullString(String s) {
+        return fromNonNullValue(s);
+    }
+
+    @Override
+    public abstract String toNonNullValue(T value);
+
+    @Override
+    public final String toNonNullString(T value) {
+        return toNonNullValue(value);
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/AbstractUserType.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/AbstractUserType.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2010, 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import java.io.Serializable;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.SerializationException;
+
+public abstract class AbstractUserType implements Serializable {
+
+    private static final long serialVersionUID = -3503387360213242237L;
+
+    public boolean isMutable() {
+        return false;
+    }
+
+    public boolean equals(Object x, Object y) throws HibernateException {
+        if ((x == null) && (y == null)) {
+            return true;
+        }
+        if ((x == null) || (y == null)) {
+            return false;
+        }
+        if (x == y) {
+            return true;
+        }
+        return x.equals(y);
+    }
+
+    public int hashCode(Object x) throws HibernateException {
+        assert (x != null);
+        return x.hashCode();
+    }
+
+    public Object assemble(Serializable cachedValue, Object owner) throws HibernateException {
+        return deepCopy(cachedValue);
+    }
+
+    public Serializable disassemble(Object value) throws HibernateException {
+
+        final Serializable result;
+
+        if (value == null) {
+            result = null;
+        } else {
+            final Object deepCopy = deepCopy(value);
+            if (!(deepCopy instanceof Serializable)) {
+                throw new SerializationException(String.format("deepCopy of %s is not serializable", value), null);
+            }
+            result = (Serializable) deepCopy;
+        }
+
+        return result;
+    }
+
+    public Object replace(Object originalValue, Object target, Object owner) throws HibernateException {
+        return deepCopy(originalValue);
+    }
+
+    public Object deepCopy(Object value) throws HibernateException {
+        return value;
+    }
+
+    /**
+     * Included to allow session state to be applied to the user type
+     * @param session The session
+     */
+    public void beforeNullSafeOperation(SharedSessionContractImplementor session) {
+
+        ConfigurationHelper.setCurrentSessionFactory(session.getFactory());
+        if (this instanceof IntegratorConfiguredType) {
+            ((IntegratorConfiguredType)this).applyConfiguration(session.getFactory());
+        }
+    }
+
+    /**
+     * Included to allow session state to be disassociated from the user type.
+     * This should be called from a finally block for surety.
+     * @param session The session
+     */
+    public void afterNullSafeOperation(SharedSessionContractImplementor session) {
+        ConfigurationHelper.setCurrentSessionFactory(null);
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/AbstractUserTypeHibernateIntegrator.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/AbstractUserTypeHibernateIntegrator.java
@@ -1,0 +1,226 @@
+/*
+ *  Copyright 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.spi.MetadataImplementor;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+import org.hibernate.usertype.CompositeUserType;
+import org.hibernate.usertype.UserType;
+import org.jadira.usertype.spi.utils.runtime.JavaVersion;
+
+public abstract class AbstractUserTypeHibernateIntegrator implements Integrator {
+
+    private static final String REGISTER_USERTYPES_KEY = "jadira.usertype.autoRegisterUserTypes";
+
+    private static final String DEFAULT_JAVAZONE_KEY = "jadira.usertype.javaZone";
+    private static final String DEFAULT_DATABASEZONE_KEY = "jadira.usertype.databaseZone";
+    private static final String DEFAULT_SEED_KEY = "jadira.usertype.seed";
+    private static final String DEFAULT_CURRENCYCODE_KEY = "jadira.usertype.currencyCode";
+
+    private static final String JDBC42_API_KEY = "jadira.usertype.useJdbc42Apis";
+
+    public void integrate(Configuration configuration, SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
+
+        try {
+            ConfigurationHelper.setCurrentSessionFactory(sessionFactory);
+
+            String isEnabled = configuration.getProperty(REGISTER_USERTYPES_KEY);
+            String javaZone = configuration.getProperty(DEFAULT_JAVAZONE_KEY);
+            String databaseZone = configuration.getProperty(DEFAULT_DATABASEZONE_KEY);
+            String seed = configuration.getProperty(DEFAULT_SEED_KEY);
+            String currencyCode = configuration.getProperty(DEFAULT_CURRENCYCODE_KEY);
+
+            String jdbc42Apis = configuration.getProperty(JDBC42_API_KEY);
+
+            configureDefaultProperties(sessionFactory, javaZone, databaseZone, seed, currencyCode, jdbc42Apis);
+
+            if (isEnabled != null && Boolean.valueOf(isEnabled)) {
+                autoRegisterUsertypes(configuration);
+            }
+
+            final boolean use42Api = use42Api(configuration.getProperty(JDBC42_API_KEY), sessionFactory);
+            ConfigurationHelper.setUse42Api(sessionFactory, use42Api);
+
+            // doIntegrate(configuration, sessionFactory, serviceRegistry);
+        } finally {
+            ConfigurationHelper.setCurrentSessionFactory(null);
+        }
+    }
+
+    private boolean use42Api(String jdbc42Apis, SessionFactoryImplementor sessionFactory) {
+
+        boolean use42Api;
+        if (jdbc42Apis == null) {
+
+            if (JavaVersion.isJava8OrLater()) {
+
+                Connection conn = null;
+                try {
+                    JdbcServices jdbcServices = sessionFactory.getServiceRegistry().getService(JdbcServices.class);
+                    conn = jdbcServices.getBootstrapJdbcConnectionAccess().obtainConnection();
+
+                    DatabaseMetaData dmd = conn.getMetaData();
+                    int driverMajorVersion = dmd.getDriverMajorVersion();
+                    int driverMinorVersion = dmd.getDriverMinorVersion();
+
+                    if (driverMajorVersion >= 5) {
+                        use42Api = true;
+                    } else if (driverMajorVersion >= 4 && driverMinorVersion >= 2) {
+                        use42Api = true;
+                    } else {
+                        use42Api = false;
+                    }
+                } catch (SQLException e) {
+                    use42Api = false;
+                } catch (NoSuchMethodError e) {
+                    // Occurs in Hibernate 4.2.12
+                    use42Api = false;
+                } finally {
+
+                    if (conn != null) {
+                        try {
+                            conn.close();
+                        } catch (SQLException e) {
+                            // Ignore
+                        }
+                    }
+                }
+            } else {
+                use42Api = false;
+            }
+        } else {
+            use42Api = Boolean.parseBoolean(jdbc42Apis);
+        }
+        return use42Api;
+    }
+
+    private void autoRegisterUsertypes(Configuration configuration) {
+
+        for(UserType next : getUserTypes()) {
+
+            registerType(configuration, next);
+        }
+
+        for(CompositeUserType next : getCompositeUserTypes()) {
+
+            registerType(configuration, next);
+        }
+    }
+
+    private void autoRegisterUsertypes(MetadataImplementor configuration) {
+
+        for(UserType next : getUserTypes()) {
+
+            registerType(configuration, next);
+        }
+
+        for(CompositeUserType next : getCompositeUserTypes()) {
+
+            registerType(configuration, next);
+        }
+    }
+
+    private void configureDefaultProperties(SessionFactoryImplementor sessionFactory, String javaZone, String databaseZone, String seed, String currencyCode, String jdbc42Apis) {
+        Properties properties = new Properties();
+        if (databaseZone != null) { properties.put("databaseZone", databaseZone); }
+        if (javaZone != null) { properties.put("javaZone", javaZone); }
+        if (seed != null) { properties.put("seed", seed); }
+        if (currencyCode != null) { properties.put("currencyCode", currencyCode); }
+        if (jdbc42Apis != null) { properties.put("jdbc42Apis", jdbc42Apis); }
+        ConfigurationHelper.configureDefaultProperties(sessionFactory, properties);
+    }
+
+    private void registerType(Configuration configuration, CompositeUserType type) {
+        String className = type.returnedClass().getName();
+        configuration.registerTypeOverride(type, new String[] {className});
+    }
+
+    private void registerType(Configuration configuration, UserType type) {
+        String className = type.returnedClass().getName();
+        configuration.registerTypeOverride(type, new String[] {className});
+    }
+
+    private void registerType(MetadataImplementor mi, CompositeUserType type) {
+        String className = type.returnedClass().getName();
+        mi.getTypeResolver().registerTypeOverride(type, new String[] {className});
+    }
+
+    private void registerType(MetadataImplementor mi, UserType type) {
+        String className = type.returnedClass().getName();
+        mi.getTypeResolver().registerTypeOverride(type, new String[] {className});
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void integrate(Metadata metadata, SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
+
+        final MetadataImplementor mi;
+        if (metadata instanceof MetadataImplementor) {
+            mi = (MetadataImplementor)metadata;
+        } else {
+            throw new IllegalArgumentException("Metadata was not assignable to MetadataImplementor: " + metadata.getClass());
+        }
+
+        try {
+            ConfigurationHelper.setCurrentSessionFactory(sessionFactory);
+
+            String isEnabled = (String)sessionFactory.getProperties().get(REGISTER_USERTYPES_KEY);
+            String javaZone = (String)sessionFactory.getProperties().get(DEFAULT_JAVAZONE_KEY);
+            String databaseZone = (String)sessionFactory.getProperties().get(DEFAULT_DATABASEZONE_KEY);
+            String seed = (String)sessionFactory.getProperties().get(DEFAULT_SEED_KEY);
+            String currencyCode = (String)sessionFactory.getProperties().get(DEFAULT_CURRENCYCODE_KEY);
+
+            String jdbc42Apis = (String)sessionFactory.getProperties().get(JDBC42_API_KEY);
+
+            configureDefaultProperties(sessionFactory, javaZone, databaseZone, seed, currencyCode, jdbc42Apis);
+
+            if (isEnabled != null && Boolean.valueOf(isEnabled)) {
+                autoRegisterUsertypes(mi);
+            }
+
+            final boolean use42Api = use42Api(jdbc42Apis, sessionFactory);
+            ConfigurationHelper.setUse42Api(sessionFactory, use42Api);
+
+            // doIntegrate(mi, sessionFactory, serviceRegistry);
+        } finally {
+            ConfigurationHelper.setCurrentSessionFactory(null);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void disintegrate(SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
+        ConfigurationHelper.configureDefaultProperties(sessionFactory, null);
+    }
+
+    protected abstract CompositeUserType[] getCompositeUserTypes();
+
+    protected abstract UserType[] getUserTypes();
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/ColumnMapper.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/ColumnMapper.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2010, 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import org.hibernate.type.SingleColumnType;
+
+public interface ColumnMapper<T, J> {
+
+    SingleColumnType<? super J> getHibernateType();
+
+    int getSqlType();
+
+    T fromNonNullValue(J value);
+
+    T fromNonNullString(String s);
+
+    J toNonNullValue(T value);
+
+    String toNonNullString(T value);
+
+    Class<T> returnedClass();
+
+    Class<J> jdbcClass();
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/ColumnMapperSingleColumnTypeAdapter.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/ColumnMapperSingleColumnTypeAdapter.java
@@ -1,0 +1,324 @@
+/*
+ *  Copyright 2010, 2011, 2012 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+import org.hibernate.HibernateException;
+import org.hibernate.MappingException;
+import org.hibernate.engine.jdbc.Size;
+import org.hibernate.engine.spi.Mapping;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.ForeignKeyDirection;
+import org.hibernate.type.SingleColumnType;
+import org.hibernate.type.Type;
+
+public class ColumnMapperSingleColumnTypeAdapter<T,J> implements SingleColumnType<T> {
+
+    private static final long serialVersionUID = -8396126842631394890L;
+
+    private ColumnMapper<T, J> columnMapper;
+
+    public ColumnMapperSingleColumnTypeAdapter(ColumnMapper<T, J> columnMapper) {
+        this.columnMapper = columnMapper;
+    }
+
+    @Override
+    public boolean isAssociationType() {
+        return columnMapper.getHibernateType().isAssociationType();
+    }
+
+    @Override
+    public boolean isCollectionType() {
+        return columnMapper.getHibernateType().isCollectionType();
+    }
+
+    @Override
+    public boolean isEntityType() {
+        return columnMapper.getHibernateType().isEntityType();
+    }
+
+    @Override
+    public boolean isAnyType() {
+        return columnMapper.getHibernateType().isAnyType();
+    }
+
+    @Override
+    public boolean isComponentType() {
+        return columnMapper.getHibernateType().isComponentType();
+    }
+
+    @Override
+    public int getColumnSpan(Mapping mapping) throws MappingException {
+        return columnMapper.getHibernateType().getColumnSpan(mapping);
+    }
+
+    @Override
+    public int[] sqlTypes(Mapping mapping) throws MappingException {
+        return new int[] { columnMapper.getSqlType() };
+    }
+
+    @Override
+    public Size[] dictatedSizes(Mapping mapping) throws MappingException {
+        return columnMapper.getHibernateType().dictatedSizes(mapping);
+    }
+
+    @Override
+    public Size[] defaultSizes(Mapping mapping) throws MappingException {
+        return columnMapper.getHibernateType().defaultSizes(mapping);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Class getReturnedClass() {
+        return columnMapper.returnedClass();
+    }
+
+    @Override
+    public boolean isSame(Object x, Object y) throws HibernateException {
+        return columnMapper.getHibernateType().isSame(x, y);
+    }
+
+    @Override
+    public boolean isEqual(Object x, Object y) throws HibernateException {
+        return columnMapper.getHibernateType().isEqual(x, y);
+    }
+
+    @Override
+    public boolean isEqual(Object x, Object y, SessionFactoryImplementor factory)
+            throws HibernateException {
+        return columnMapper.getHibernateType().isEqual(x, y, factory);
+    }
+
+    @Override
+    public int getHashCode(Object x) throws HibernateException {
+        return columnMapper.getHibernateType().getHashCode(x);
+    }
+
+    @Override
+    public int getHashCode(Object x, SessionFactoryImplementor factory)
+            throws HibernateException {
+        return columnMapper.getHibernateType().getHashCode(x, factory);
+    }
+
+    @Override
+    public int compare(Object x, Object y) {
+        return columnMapper.getHibernateType().compare(x, y);
+    }
+
+    @Override
+    public boolean isDirty(Object old, Object current,
+                           SharedSessionContractImplementor session) throws HibernateException {
+        return columnMapper.getHibernateType().isDirty(old, current, session);
+    }
+
+    @Override
+    public boolean isDirty(Object oldState, Object currentState,
+                           boolean[] checkable, SharedSessionContractImplementor session)
+            throws HibernateException {
+        return columnMapper.getHibernateType().isDirty(oldState, currentState, checkable, session);
+    }
+
+    @Override
+    public boolean isModified(Object dbState, Object currentState,
+                              boolean[] checkable, SharedSessionContractImplementor session)
+            throws HibernateException {
+        return columnMapper.getHibernateType().isModified(dbState, currentState, checkable, session);
+    }
+
+
+    @Override
+    public Object nullSafeGet(ResultSet rs, String[] names,
+                              SharedSessionContractImplementor session, Object owner)
+            throws HibernateException, SQLException {
+
+        @SuppressWarnings("unchecked") final J hibernateValue = (J)(columnMapper.getHibernateType().nullSafeGet(rs, names, session, owner));
+        if (hibernateValue == null) {
+            return null;
+        }
+        return columnMapper.fromNonNullValue(hibernateValue);
+    }
+
+    @Override
+    public Object nullSafeGet(ResultSet rs, String name,
+                              SharedSessionContractImplementor session, Object owner)
+            throws HibernateException, SQLException {
+
+        @SuppressWarnings("unchecked") final J hibernateValue = (J) columnMapper.getHibernateType().nullSafeGet(rs, name, session, owner);
+        if (hibernateValue == null) {
+            return null;
+        }
+        return columnMapper.fromNonNullValue(hibernateValue);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void nullSafeSet(PreparedStatement st, Object value, int index,
+                            boolean[] settable, SharedSessionContractImplementor session)
+            throws HibernateException, SQLException {
+
+        final Object param = value == null ? null : columnMapper.fromNonNullValue((J) value);
+        columnMapper.getHibernateType().nullSafeSet(st, param, index, settable, session);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void nullSafeSet(PreparedStatement st, Object value, int index,
+                            SharedSessionContractImplementor session) throws HibernateException, SQLException {
+
+        final Object param = value == null ? null : columnMapper.toNonNullValue((T) value);
+        columnMapper.getHibernateType().nullSafeSet(st, param, index, session);
+    }
+
+    @Override
+    public String toLoggableString(Object value,
+                                   SessionFactoryImplementor factory) throws HibernateException {
+        return columnMapper.getHibernateType().toLoggableString(value, factory);
+    }
+
+    @Override
+    public String getName() {
+        return columnMapper.returnedClass().getSimpleName();
+    }
+
+    @Override
+    public Object deepCopy(Object value, SessionFactoryImplementor factory)
+            throws HibernateException {
+        return columnMapper.getHibernateType().deepCopy(value, factory);
+    }
+
+    @Override
+    public boolean isMutable() {
+        return columnMapper.getHibernateType().isMutable();
+    }
+
+    @Override
+    public Serializable disassemble(Object value, SharedSessionContractImplementor session,
+                                    Object owner) throws HibernateException {
+        return columnMapper.getHibernateType().disassemble(value, session, owner);
+    }
+
+    @Override
+    public Object assemble(Serializable cached, SharedSessionContractImplementor session,
+                           Object owner) throws HibernateException {
+        return columnMapper.getHibernateType().assemble(cached, session, owner);
+    }
+
+    @Override
+    public void beforeAssemble(Serializable cached, SharedSessionContractImplementor session) {
+        columnMapper.getHibernateType().beforeAssemble(cached, session);
+    }
+
+    @Override
+    public Object hydrate(ResultSet rs, String[] names,
+                          SharedSessionContractImplementor session, Object owner)
+            throws HibernateException, SQLException {
+        return columnMapper.getHibernateType().hydrate(rs, names, session, owner);
+    }
+
+    @Override
+    public Object resolve(Object value, SharedSessionContractImplementor session, Object owner)
+            throws HibernateException {
+        return columnMapper.getHibernateType().resolve(value, session, owner);
+    }
+
+    @Override
+    public Object semiResolve(Object value, SharedSessionContractImplementor session,
+                              Object owner) throws HibernateException {
+        return columnMapper.getHibernateType().semiResolve(value, session, owner);
+    }
+
+    @Override
+    public Type getSemiResolvedType(SessionFactoryImplementor factory) {
+        return this;
+    }
+
+    @Override
+    public Object replace(Object original, Object target,
+                          SharedSessionContractImplementor session, Object owner, @SuppressWarnings("rawtypes") Map copyCache)
+            throws HibernateException {
+        return columnMapper.getHibernateType().replace(original, target, session, owner, copyCache);
+    }
+
+    @Override
+    public Object replace(Object original, Object target,
+                          SharedSessionContractImplementor session, Object owner, @SuppressWarnings("rawtypes") Map copyCache,
+                          ForeignKeyDirection foreignKeyDirection) throws HibernateException {
+        return columnMapper.getHibernateType().replace(original, target, session, owner, copyCache, foreignKeyDirection);
+    }
+
+    @Override
+    public boolean[] toColumnNullness(Object value, Mapping mapping) {
+        return columnMapper.getHibernateType().toColumnNullness(value, mapping);
+    }
+
+    @Override
+    public int sqlType() {
+        return columnMapper.getSqlType();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public String toString(Object value) throws HibernateException {
+        if (value == null) {
+            return null;
+        }
+        return columnMapper.toNonNullString((T) value);
+    }
+
+    @Override
+    public T fromStringValue(String xml) throws HibernateException {
+        if (xml == null) {
+            return null;
+        }
+        return columnMapper.fromNonNullString(xml);
+    }
+
+    @Override
+    public T nullSafeGet(ResultSet rs, String name,
+                         SharedSessionContractImplementor session) throws HibernateException, SQLException {
+
+        @SuppressWarnings("unchecked") final J hibernateValue = (J) columnMapper.getHibernateType().nullSafeGet(rs, name, session);
+        if (hibernateValue == null) {
+            return null;
+        }
+        return columnMapper.fromNonNullValue(hibernateValue);
+    }
+
+    @Override
+    public Object get(ResultSet rs, String name, SharedSessionContractImplementor session)
+            throws HibernateException, SQLException {
+
+        @SuppressWarnings("unchecked") final J hibernateValue = (J)(columnMapper.getHibernateType().get(rs, name, session));
+        if (hibernateValue == null) {
+            return null;
+        }
+        return columnMapper.fromNonNullValue(hibernateValue);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void set(PreparedStatement st, Object value, int index,
+                    SharedSessionContractImplementor session) throws HibernateException, SQLException {
+
+        final Object param = value == null ? null : columnMapper.toNonNullValue((T) value);
+        columnMapper.getHibernateType().nullSafeSet(st, param, index, session);	}
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/ConfigurationHelper.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/ConfigurationHelper.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.hibernate.SessionFactory;
+
+public final class ConfigurationHelper {
+
+    private static ThreadLocal<SessionFactory> currentSessionFactory = new ThreadLocal<SessionFactory>();
+
+    private static final Map<SessionFactory, Properties> DEFAULT_PROPERTIES = new HashMap<SessionFactory, Properties>();
+
+    private static final Map<SessionFactory, Boolean> DEFAULT_USEJDBC42 = new HashMap<SessionFactory, Boolean>();
+
+    private ConfigurationHelper() {
+    }
+
+    public static String getProperty(String key) {
+
+        SessionFactory current = currentSessionFactory.get();
+        if (current != null) {
+            Properties defaults = DEFAULT_PROPERTIES.get(current);
+            if (defaults != null) {
+                return defaults.getProperty(key);
+            }
+        }
+        return null;
+    }
+
+    public static boolean getUse42Api() {
+        SessionFactory current = currentSessionFactory.get();
+        if (current != null) {
+            return DEFAULT_USEJDBC42.get(current);
+        }
+        return false;
+    }
+
+    static void setUse42Api(SessionFactory sessionFactory, boolean use42Api) {
+        DEFAULT_USEJDBC42.put(sessionFactory, use42Api);
+    }
+
+    static void setCurrentSessionFactory(SessionFactory sessionFactory) {
+        currentSessionFactory.set(sessionFactory);
+    }
+
+    static void configureDefaultProperties(SessionFactory sessionFactory, Properties properties) {
+        if (properties == null) {
+            DEFAULT_PROPERTIES.remove(sessionFactory);
+            DEFAULT_USEJDBC42.remove(sessionFactory);
+        } else {
+            DEFAULT_PROPERTIES.put(sessionFactory, properties);
+        }
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/shared/IntegratorConfiguredType.java
+++ b/src/main/java/org/jadira/usertype/spi/shared/IntegratorConfiguredType.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.shared;
+
+import org.hibernate.SessionFactory;
+
+/**
+ * Represents a type that can be configured by an {@link org.hibernate.integrator.spi.Integrator} or that take additional configuration from the {@link SessionFactory}.
+ * Typically these types are configured at runtime prior to the execution of null safe get. This is necessary because integrators are
+ * invoked following the discovery of annotated types.
+ */
+public interface IntegratorConfiguredType {
+
+    /**
+     * Apply configuration for the given type
+     * @param sessionFactory The currently active session factory
+     */
+    void applyConfiguration(SessionFactory sessionFactory);
+}

--- a/src/main/java/org/jadira/usertype/spi/utils/lang/ConcurrentHashMapBackedProperties.java
+++ b/src/main/java/org/jadira/usertype/spi/utils/lang/ConcurrentHashMapBackedProperties.java
@@ -1,0 +1,330 @@
+package org.jadira.usertype.spi.utils.lang;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.InvalidPropertiesFormatException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class ConcurrentHashMapBackedProperties extends Properties {
+
+    private static final long serialVersionUID = 23632462472472L;
+
+    private ConcurrentHashMap<Object, Object> properties = new ConcurrentHashMap<>();
+
+    public ConcurrentHashMapBackedProperties(Properties properties) {
+        this.properties.putAll((Map<Object, Object>) properties);
+    }
+
+    public ConcurrentHashMapBackedProperties(ConcurrentHashMapBackedProperties cloneFrom) {
+        this.properties = new ConcurrentHashMap<>(cloneFrom.properties);
+    }
+
+    public ConcurrentHashMapBackedProperties() {
+        super();
+        properties = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public Object setProperty(String key, String value) {
+        return properties.put(key, value);
+    }
+
+    @Override
+    public String getProperty(String key) {
+        return (String) this.properties.get(key);
+    }
+
+    @Override
+    public String getProperty(String key, String defaultValue) {
+        String val = getProperty(key);
+        return (val == null) ? defaultValue : val;
+    }
+
+    @Override
+    public Enumeration<?> propertyNames() {
+        return properties.keys();
+    }
+
+    @Override
+    public Set<String> stringPropertyNames() {
+        ConcurrentHashMap<String, String> strProps = new ConcurrentHashMap<>();
+        for (Enumeration<?> e = keys(); e.hasMoreElements();) {
+            Object k = e.nextElement();
+            Object v = get(k);
+            if (k instanceof String && v instanceof String) {
+                this.properties.put((String) k, (String) v);
+            }
+        }
+        return strProps.keySet();
+    }
+
+    @Override
+    public void load(Reader reader) throws IOException {
+        try{
+            super.load(reader);
+            this.properties.putAll(this);
+        }
+        finally{
+            super.clear();
+        }
+    }
+
+    @Override
+    public void load(InputStream inStream) throws IOException {
+        try {
+            super.load(inStream);
+            this.properties.putAll(this);
+        } finally {
+            super.clear();
+        }
+    }
+
+    @Override
+    @Deprecated
+    public void save(OutputStream out, String comments) {
+        try {
+            store(out, comments);
+        } catch (IOException e) {
+        }
+    }
+
+    @Override
+    public void store(Writer writer, String comments) throws IOException {
+        store((writer instanceof BufferedWriter) ? (BufferedWriter) writer : new BufferedWriter(writer), comments);
+    }
+
+    @Override
+    public void store(OutputStream out, String comments) throws IOException {
+        store(new BufferedWriter(new OutputStreamWriter(out)), comments);
+    }
+
+    private void store(BufferedWriter bw, String comments) throws IOException {
+        if (comments != null) {
+            // TODO write comments
+        }
+        bw.write("#" + new Date().toString());
+        bw.newLine();
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            String key = entry.getKey().toString();
+            String val = entry.getValue().toString();
+            bw.write(key + "=" + val);
+            bw.newLine();
+        }
+        bw.flush();
+    }
+
+    @Override
+    public void list(PrintStream out) {
+        out.println("-- listing properties --");
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            out.println(entry.getKey().toString() + "=" + entry.getValue().toString());
+        }
+    }
+
+    @Override
+    public void list(PrintWriter out) {
+        out.println("-- listing properties --");
+        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+            out.println(entry.getKey().toString() + "=" + entry.getValue().toString());
+        }
+    }
+
+    @Override
+    public void loadFromXML(InputStream in) throws IOException, InvalidPropertiesFormatException {
+        try{
+            super.loadFromXML(in);
+            this.properties.putAll(this);
+        }
+        finally{
+            super.clear();
+        }
+    }
+
+    @Override // TODO
+    public void storeToXML(OutputStream os, String comment) throws IOException {
+
+        throw new UnsupportedOperationException("Error: This method is not supported");
+    }
+
+    @Override // TODO
+    public void storeToXML(OutputStream os, String comment, String encoding) throws IOException {
+
+        throw new UnsupportedOperationException("Error: This method is not supported");
+    }
+
+    // Overriding Hashtable
+
+    @Override
+    public int size() {
+        return properties.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return properties.isEmpty();
+    }
+
+    @Override
+    public Enumeration<Object> keys() {
+        return properties.keys();
+    }
+
+    @Override
+    public Enumeration<Object> elements() {
+        return properties.elements();
+    }
+
+    @Override
+    public boolean contains(Object value) {
+        return properties.contains(value);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return properties.containsValue(value);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return properties.containsKey(key);
+    }
+
+    @Override
+    public Object get(Object key) {
+        return properties.get(key);
+    }
+
+    @Override
+    public Object put(Object key, Object value) {
+        return properties.put((String) key, (String) value);
+    }
+
+    @Override
+    public Object remove(Object key) {
+        return properties.remove(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void putAll(Map<? extends Object, ? extends Object> t) {
+        properties.putAll((Map<Object, Object>) t);
+    }
+
+    @Override
+    public void clear() {
+        properties.clear();
+    }
+
+    @Override
+    public String toString() {
+        return properties.toString();
+    }
+
+    @Override
+    public Set<Object> keySet() {
+        return properties.keySet();
+    }
+
+    @Override
+    public Set<java.util.Map.Entry<Object, Object>> entrySet() {
+        return properties.entrySet();
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return properties.values();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return properties.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return properties.hashCode();
+    }
+
+    @Override
+    public Object getOrDefault(Object key, Object defaultValue) {
+        return properties.getOrDefault((String) key, (String) defaultValue);
+    }
+
+    @Override
+    public void forEach(BiConsumer<? super Object, ? super Object> action) {
+        properties.forEach(action);
+    }
+
+    @Override
+    public void replaceAll(BiFunction<? super Object, ? super Object, ? extends Object> function) {
+        properties.replaceAll(function);
+    }
+
+    @Override
+    public Object putIfAbsent(Object key, Object value) {
+        return properties.putIfAbsent((String) key, (String) value);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        return properties.remove(key, value);
+    }
+
+    @Override
+    public boolean replace(Object key, Object oldValue, Object newValue) {
+        return properties.replace((String) key, (String) oldValue, (String) newValue);
+    }
+
+    @Override
+    public Object replace(Object key, Object value) {
+        return properties.replace((String) key, (String) value);
+    }
+
+    @Override
+    public Object computeIfAbsent(Object key, Function<? super Object, ? extends Object> mappingFunction) {
+        return properties.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public Object computeIfPresent(Object key,
+                                   BiFunction<? super Object, ? super Object, ? extends Object> remappingFunction) {
+        return properties.computeIfPresent(key, remappingFunction);
+    }
+
+    @Override
+    public Object compute(Object key, BiFunction<? super Object, ? super Object, ? extends Object> remappingFunction) {
+        return properties.compute(key, remappingFunction);
+    }
+
+    @Override
+    public Object merge(Object key, Object value,
+                        BiFunction<? super Object, ? super Object, ? extends Object> remappingFunction) {
+        return properties.merge(key, value, remappingFunction);
+    }
+
+    @Override
+    public Object clone() {
+        return new ConcurrentHashMapBackedProperties(this);
+    }
+
+    @Override // TODO
+    protected void rehash() {
+        throw new UnsupportedOperationException("Error: This method is not supported");
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/utils/reflection/ArrayUtils.java
+++ b/src/main/java/org/jadira/usertype/spi/utils/reflection/ArrayUtils.java
@@ -1,0 +1,140 @@
+/*
+ *  Copyright 2010, 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.utils.reflection;
+
+import java.lang.reflect.Array;
+
+/**
+ * Utility methods for manipulating arrays
+ * @author Chris Pheby
+ */
+public final class ArrayUtils {
+
+    private ArrayUtils() {
+    }
+
+    /**
+     * This method does a similar job to JSE 6.0's Arrays.copyOf() method
+     * @param <U> The type of input array
+     * @param objectArray The array to copy
+     * @return A copy of the input, of component type U
+     */
+    public static <U> U[] copyOf(U[] objectArray) {
+
+        Class<?> arrayClass = objectArray.getClass();
+        @SuppressWarnings("unchecked") Class<U> componentClass = (Class<U>) arrayClass.getComponentType();
+
+        @SuppressWarnings("unchecked") U[] copy = (U[]) Array.newInstance(componentClass, objectArray.length);
+        System.arraycopy(objectArray, 0, copy, 0, objectArray.length);
+        return copy;
+    }
+
+    /**
+     * This method does a similar job to JSE 6.0's Arrays.copyOf() method and overloads the method for use with arrays of ints
+     * @param intArray The array to copy
+     * @return A copy of the input, of component type U
+     */
+    public static int[] copyOf(int[] intArray) {
+
+        int[] copy = new int[intArray.length];
+        System.arraycopy(intArray, 0, copy, 0, intArray.length);
+        return copy;
+    }
+
+    /**
+     * This method does a similar job to JSE 6.0's Arrays.copyOf() method and overloads the method for use with arrays of short
+     * @param shortArray The array to copy
+     * @return A copy of the input, of component type U
+     */
+    public static short[] copyOf(short[] shortArray) {
+
+        short[] copy = new short[shortArray.length];
+        System.arraycopy(shortArray, 0, copy, 0, shortArray.length);
+        return copy;
+    }
+
+    /**
+     * This method does a similar job to JSE 6.0's Arrays.copyOf() method and overloads the method for use with arrays of long
+     * @param longArray The array to copy
+     * @return A copy of the input, of component type U
+     */
+    public static long[] copyOf(long[] longArray) {
+
+        long[] copy = new long[longArray.length];
+        System.arraycopy(longArray, 0, copy, 0, longArray.length);
+        return copy;
+    }
+
+    /**
+     * This method does a similar job to JSE 6.0's Arrays.copyOf() method and overloads the method for use with arrays of byte
+     * @param byteArray The array to copy
+     * @return A copy of the input, of component type U
+     */
+    public static byte[] copyOf(byte[] byteArray) {
+
+        byte[] copy = new byte[byteArray.length];
+        System.arraycopy(byteArray, 0, copy, 0, byteArray.length);
+        return copy;
+    }
+
+    /**
+     * This method does a similar job to JSE 6.0's Arrays.copyOf() method and overloads the method for use with arrays of char
+     * @param charArray The array to copy
+     * @return A copy of the input, of component type U
+     */
+    public static char[] copyOf(char[] charArray) {
+
+        char[] copy = new char[charArray.length];
+        System.arraycopy(charArray, 0, copy, 0, charArray.length);
+        return copy;
+    }
+
+    /**
+     * This method does a similar job to JSE 6.0's Arrays.copyOf() method and overloads the method for use with arrays of float
+     * @param floatArray The array to copy
+     * @return A copy of the input, of component type U
+     */
+    public static float[] copyOf(float[] floatArray) {
+
+        float[] copy = new float[floatArray.length];
+        System.arraycopy(floatArray, 0, copy, 0, floatArray.length);
+        return copy;
+    }
+
+    /**
+     * This method does a similar job to JSE 6.0's Arrays.copyOf() method and overloads the method for use with arrays of double
+     * @param doubleArray The array to copy
+     * @return A copy of the input, of component type U
+     */
+    public static double[] copyOf(double[] doubleArray) {
+
+        double[] copy = new double[doubleArray.length];
+        System.arraycopy(doubleArray, 0, copy, 0, doubleArray.length);
+        return copy;
+    }
+
+    /**
+     * This method does a similar job to JSE 6.0's Arrays.copyOf() method and overloads the method for use with arrays of boolean
+     * @param booleanArray The array to copy
+     * @return A copy of the input, of component type U
+     */
+    public static boolean[] copyOf(boolean[] booleanArray) {
+
+        boolean[] copy = new boolean[booleanArray.length];
+        System.arraycopy(booleanArray, 0, copy, 0, booleanArray.length);
+        return copy;
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/utils/reflection/ClassLoaderUtils.java
+++ b/src/main/java/org/jadira/usertype/spi/utils/reflection/ClassLoaderUtils.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2010, 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.utils.reflection;
+
+/**
+ * Utility methods related to {@link ClassLoader} resolution and the like
+ */
+public final class ClassLoaderUtils {
+
+    private ClassLoaderUtils() {
+    }
+
+    /**
+     * Gets an appropriate {@link ClassLoader} for the current thread
+     * @return The ClassLoader
+     */
+    public static ClassLoader getClassLoader() {
+
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+
+        if (cl == null) {
+            cl = ClassLoaderUtils.class.getClassLoader();
+        }
+
+        return cl;
+    }
+
+    /**
+     * Attempts to instantiate the named class, using the context ClassLoader for the current thread,
+     * or Class.forName if this does not work
+     * @param name The class name
+     * @return The Class instance
+     * @throws ClassNotFoundException If the class cannot be found
+     */
+    public static Class<?> classForName(String name) throws ClassNotFoundException {
+
+        ClassLoader cl = getClassLoader();
+        try {
+            if (cl != null) {
+                return cl.loadClass(name);
+            }
+        } catch (ClassNotFoundException e) {
+            // Ignore and try using Class.forName()
+        }
+        return Class.forName(name);
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/utils/reflection/TypeHelper.java
+++ b/src/main/java/org/jadira/usertype/spi/utils/reflection/TypeHelper.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2010, 2011 Christopher Pheby
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.jadira.usertype.spi.utils.reflection;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Originally based on http://www.artima.com/weblogs/viewpost.jsp?thread=208860
+ */
+public final class TypeHelper {
+
+    private TypeHelper() {
+    }
+
+    /**
+     * Get the underlying class for a type, or null if the type is a variable type.
+     * @param type the type
+     * @return the underlying class
+     */
+    public static Class<?> getClass(Type type) {
+        if (type instanceof Class<?>) {
+            return (Class<?>) type;
+        } else if (type instanceof ParameterizedType) {
+            return getClass(((ParameterizedType) type).getRawType());
+        } else if (type instanceof GenericArrayType) {
+            Type componentType = ((GenericArrayType) type).getGenericComponentType();
+            Class<?> componentClass = getClass(componentType);
+            if (componentClass != null) {
+                return Array.newInstance(componentClass, 0).getClass();
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get the actual type arguments a child class has used to extend a generic base class.
+     * @param baseClass the base class
+     * @param childClass the child class
+     * @param <T> The type of the base class against which the type arguments relate
+     * @return a list of the raw classes for the actual type arguments.
+     */
+    public static <T> List<Class<?>> getTypeArguments(Class<T> baseClass, Class<? extends T> childClass) {
+        Map<Type, Type> resolvedTypes = new HashMap<Type, Type>();
+        Type type = childClass;
+        // start walking up the inheritance hierarchy until we hit baseClass
+        while (!getClass(type).equals(baseClass)) {
+            if (type instanceof Class<?>) {
+                // there is no useful information for us in raw types, so just keep going.
+                type = ((Class<?>) type).getGenericSuperclass();
+            } else {
+                ParameterizedType parameterizedType = (ParameterizedType) type;
+                Class<?> rawType = (Class<?>) parameterizedType.getRawType();
+
+                Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+                TypeVariable<?>[] typeParameters = rawType.getTypeParameters();
+                for (int i = 0; i < actualTypeArguments.length; i++) {
+                    resolvedTypes.put(typeParameters[i], actualTypeArguments[i]);
+                }
+
+                if (!rawType.equals(baseClass)) {
+                    type = rawType.getGenericSuperclass();
+                }
+            }
+        }
+
+        // finally, for each actual type argument provided to baseClass, determine (if possible)
+        // the raw class for that type argument.
+        Type[] actualTypeArguments;
+        if (type instanceof Class<?>) {
+            actualTypeArguments = ((Class<?>) type).getTypeParameters();
+        } else {
+            actualTypeArguments = ((ParameterizedType) type).getActualTypeArguments();
+        }
+        List<Class<?>> typeArgumentsAsClasses = new ArrayList<Class<?>>();
+        // resolve types by chasing down type variables.
+        for (Type baseType : actualTypeArguments) {
+            while (resolvedTypes.containsKey(baseType)) {
+                baseType = resolvedTypes.get(baseType);
+            }
+            typeArgumentsAsClasses.add(getClass(baseType));
+        }
+        return typeArgumentsAsClasses;
+    }
+}

--- a/src/main/java/org/jadira/usertype/spi/utils/runtime/JavaVersion.java
+++ b/src/main/java/org/jadira/usertype/spi/utils/runtime/JavaVersion.java
@@ -1,0 +1,69 @@
+package org.jadira.usertype.spi.utils.runtime;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Provides a convenient capability to retrieve the version of Java
+ */
+public class JavaVersion {
+
+    private static final Pattern JDK9_AND_HIGHER = Pattern.compile("([1-9][0-9]*)(\\.(\\d+))?.*");
+
+    public static final int MAJOR_VERSION;
+    public static final int MINOR_VERSION;
+
+    static {
+        Version version = parseVersion(System.getProperty("java.version"));
+        MAJOR_VERSION = version.major;
+        MINOR_VERSION = version.minor;
+    }
+
+    static Version parseVersion(String version) {
+        if (version.startsWith("1.")) {
+            String[] versions = version.split("\\.");
+            if (versions.length <= 1) {
+                throw new IllegalStateException("Invalid Java version: " + version);
+            }
+            return new Version(1, Integer.parseInt(versions[1]));
+        } else {
+            final Matcher matcher = JDK9_AND_HIGHER.matcher(version);
+            if (matcher.matches()) {
+                int major = Integer.parseInt(matcher.group(1));
+                String minorGroup = matcher.group(3);
+                int minor = minorGroup != null && !minorGroup.isEmpty() ? Integer.parseInt(minorGroup) : 0;
+                return new Version(major, minor);
+            } else {
+                throw new IllegalStateException("Invalid Java version: " + version);
+            }
+        }
+    }
+
+    public static final int getMajorVersion() {
+        return MAJOR_VERSION;
+    }
+
+    public static final int getMinorVersion() {
+        return MINOR_VERSION;
+    }
+
+    public static boolean isJava8OrLater() {
+        if (getMajorVersion() > 1) {
+            return true;
+        } else if (getMajorVersion() == 1 && getMinorVersion() >= 8) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    static class Version {
+        final int major;
+        final int minor;
+
+        Version(int major, int minor) {
+            this.major = major;
+            this.minor = minor;
+        }
+    }
+}

--- a/src/main/java/ru/kappers/config/SecurityConfig.java
+++ b/src/main/java/ru/kappers/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.session.HttpSessionEventPublisher;
+import ru.kappers.model.Role;
 
 import javax.sql.DataSource;
 
@@ -54,7 +55,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         "/sign-in/get-authority",
                         "/rest/dict/**"
                 ).permitAll()
-                .antMatchers("/rest/api/fixtures/twoweeks").hasAnyAuthority("ROLE_ADMIN")
+                .antMatchers("/rest/api/fixtures/twoweeks").hasAnyAuthority(Role.Names.ADMIN)
                 .anyRequest().authenticated()
 //                .and()
 //                .sessionManagement().maximumSessions(10)

--- a/src/main/java/ru/kappers/logic/controller/RaitingCotroller.java
+++ b/src/main/java/ru/kappers/logic/controller/RaitingCotroller.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import ru.kappers.model.Fixture;
+import ru.kappers.model.Role;
 import ru.kappers.model.User;
 import ru.kappers.service.UserService;
 
@@ -24,7 +25,7 @@ public class RaitingCotroller {
     @ResponseBody
     @RequestMapping(value = "/list", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public Set<User> getLastWeek() {
-        Set<User> kappers = new TreeSet<>(service.getAllByRole("ROLE_KAPPER"));
+        Set<User> kappers = new TreeSet<>(service.getAllByRole(Role.Names.KAPPER));
         return kappers;
     }
 }

--- a/src/main/java/ru/kappers/model/Role.java
+++ b/src/main/java/ru/kappers/model/Role.java
@@ -1,8 +1,8 @@
 package ru.kappers.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.collect.ImmutableList;
 import lombok.*;
-import lombok.extern.log4j.Log4j;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
@@ -10,6 +10,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * JPA-сущность для роли
+ */
 @Slf4j
 @Data
 @Builder
@@ -33,4 +36,18 @@ public class Role implements Serializable {
     @JsonIgnore
     private List<User> users = new ArrayList<>();
 
+    /**
+     * Класс констант имен ролей. Список всех имен хранится в поле {@link Names#LIST}
+     */
+    public static final class Names {
+        /** Администратор */
+        public static final String ADMIN = "ROLE_ADMIN";
+        /** Пользователь */
+        public static final String USER = "ROLE_USER";
+        /** Kapper (спортивный аналитик) */
+        public static final String KAPPER = "ROLE_KAPPER";
+
+        /** Список всех имен ролей */
+        public static final List<String> LIST = ImmutableList.of(ADMIN, USER, KAPPER);
+    }
 }

--- a/src/main/java/ru/kappers/model/User.java
+++ b/src/main/java/ru/kappers/model/User.java
@@ -2,12 +2,14 @@ package ru.kappers.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.Columns;
 import org.hibernate.annotations.NaturalId;
 import lombok.*;
+import org.hibernate.annotations.Type;
+import org.joda.money.Money;
 
 import javax.persistence.*;
 import java.io.Serializable;
-import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,13 +73,10 @@ public class User implements Serializable {
     @JsonIgnore
     private List<Event> events = new ArrayList<>();
 
-    /** Валюта */
-    @Column(name = "currency")
-    private String currency;
-
-    /** Баланс, по умолчанию 0.0 */
-    @Column(name = "balance")
-    private BigDecimal balance = BigDecimal.ZERO;
+    /** Баланс с валютой */
+    @Columns(columns = { @Column(name = "currency"), @Column(name = "balance") })
+    @Type(type = "org.jadira.usertype.moneyandcurrency.joda.PersistentMoneyAmountAndCurrency")
+    private Money balance;
 
     //
 //    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/ru/kappers/service/CurrencyService.java
+++ b/src/main/java/ru/kappers/service/CurrencyService.java
@@ -1,5 +1,6 @@
 package ru.kappers.service;
 
+import org.joda.money.CurrencyUnit;
 import ru.kappers.exceptions.CurrRateGettingException;
 
 import java.math.BigDecimal;
@@ -14,6 +15,15 @@ public interface CurrencyService {
      * @throws CurrRateGettingException если не удалось обновить курсы валют
      */
     boolean refreshCurrencyRatesForToday();
+
+    /**
+     * Конвертировать сумму из исходной валюты в целевую
+     * @param fromCurr исходная валюта
+     * @param toCurr целевая валюта
+     * @param amount сумма в исходной валюте
+     * @return сумма в целевой валюте
+     */
+    BigDecimal exchange(CurrencyUnit fromCurr, CurrencyUnit toCurr, BigDecimal amount);
 
     /**
      * Конвертировать сумму из исходной валюты в целевую

--- a/src/main/java/ru/kappers/service/impl/CurrencyServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/CurrencyServiceImpl.java
@@ -1,6 +1,7 @@
 package ru.kappers.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
+import org.joda.money.CurrencyUnit;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -92,9 +93,14 @@ public class CurrencyServiceImpl implements CurrencyService {
         return date;
     }
 
+    @Override
+    public BigDecimal exchange(CurrencyUnit fromCurr, CurrencyUnit toCurr, BigDecimal amount) {
+        return exchange(fromCurr.getCode(), toCurr.getCode(), amount);
+    }
+
     //TODO завести тесты на этот класс
     @Override
-    public BigDecimal exchange(String fromCurr, String toCurr, BigDecimal amount){
+    public BigDecimal exchange(String fromCurr, String toCurr, BigDecimal amount) {
         log.debug("exchange(fromCurr: {}, toCurr: {}, amount: {})...", fromCurr, toCurr, amount);
         if (fromCurr.equals(toCurr)) {
             return amount;

--- a/src/main/java/ru/kappers/service/impl/EventServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/EventServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import ru.kappers.exceptions.UserNotHaveKapperRoleException;
 import ru.kappers.model.Event;
 import ru.kappers.model.KapperInfo;
+import ru.kappers.model.Role;
 import ru.kappers.model.User;
 import ru.kappers.repository.EventRepository;
 import ru.kappers.service.EventService;
@@ -40,7 +41,7 @@ public class EventServiceImpl implements EventService {
     @Override
     public Event createEventByUser(Event event, User user) {
         log.debug("createEventByUser(event: {}, user: {})...", event, user);
-        if (!user.hasRole("ROLE_KAPPER")) {
+        if (!user.hasRole(Role.Names.KAPPER)) {
             throw new UserNotHaveKapperRoleException("The user " + user.getUserName() + " is not kapper");
         }
         KapperInfo kapper = kapperService.getByUser(user);

--- a/src/main/java/ru/kappers/service/impl/KapperInfoServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/KapperInfoServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.kappers.exceptions.UserNotHaveKapperRoleException;
 import ru.kappers.model.KapperInfo;
+import ru.kappers.model.Role;
 import ru.kappers.model.User;
 import ru.kappers.repository.KapperInfoRepository;
 import ru.kappers.repository.UsersRepository;
@@ -28,7 +29,7 @@ public class KapperInfoServiceImpl implements KapperInfoService {
     public KapperInfo initKapper(User user) {
         log.debug("initKapper(user: {})...", user);
         KapperInfo kapper = null;
-        if (user.hasRole("ROLE_KAPPER")) {
+        if (user.hasRole(Role.Names.KAPPER)) {
             kapper = getByUser(user);
             if (kapper == null) {
                 kapper = KapperInfo.builder().user(user).build();

--- a/src/main/java/ru/kappers/service/impl/UserServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/UserServiceImpl.java
@@ -56,7 +56,7 @@ public class UserServiceImpl implements UserService {
             user.setDateOfRegistration(DateTimeUtil.getCurrentTime());
         }
         if (user.getRole() == null) {
-            user.setRole(rolesService.getByName("ROLE_USER"));
+            user.setRole(rolesService.getByName(Role.Names.USER));
         }
         User savedUser = repository.save(user);
         saveKapperInfo(savedUser);
@@ -64,7 +64,7 @@ public class UserServiceImpl implements UserService {
     }
 
     private User saveKapperInfo(User user) {
-        if (user.getRole().equals(rolesService.getByName("ROLE_KAPPER"))) {
+        if (user.getRole().equals(rolesService.getByName(Role.Names.KAPPER))) {
             kapperInfoService.initKapper(user);
             return repository.getOne(user.getId());
         }
@@ -75,7 +75,7 @@ public class UserServiceImpl implements UserService {
     public void deleteByUserName(String userName) {
         log.debug("deleteByUserName(userName: {})...", userName);
         User user = getByUserName(userName);
-        if (user.hasRole("ROLE_KAPPER")) {
+        if (user.hasRole(Role.Names.KAPPER)) {
             kapperInfoService.delete(user);
         } else {
             repository.deleteByUserName(userName);
@@ -85,7 +85,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public void delete(User user) {
         log.debug("delete(user: {})...", user);
-        if (user.hasRole("ROLE_KAPPER")) {
+        if (user.hasRole(Role.Names.KAPPER)) {
             kapperInfoService.delete(user);
         } else {
             repository.delete(user);
@@ -185,7 +185,7 @@ public class UserServiceImpl implements UserService {
     @Transactional(readOnly = true)
     public KapperInfo getKapperInfo(User user) {
         log.debug("getKapperInfo(user: {})...", user);
-        if (user.hasRole("ROLE_KAPPER")) {
+        if (user.hasRole(Role.Names.KAPPER)) {
             return user.getKapperInfo();
         }
         return null;
@@ -204,8 +204,8 @@ public class UserServiceImpl implements UserService {
     @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
     public synchronized void transfer(User user, User kapper, BigDecimal amount){
         log.debug("transfer(user: {}, kapper: {}, amount: {})...", user, kapper, amount);
-        Preconditions.checkArgument(user.hasRole("ROLE_USER"), "User %s has no permission to transfer money", user.getUserName());
-        Preconditions.checkArgument(kapper.hasRole("ROLE_KAPPER"), "The operation is forbidden. Money can be transfered only from user to kapper");
+        Preconditions.checkArgument(user.hasRole(Role.Names.USER), "User %s has no permission to transfer money", user.getUserName());
+        Preconditions.checkArgument(kapper.hasRole(Role.Names.KAPPER), "The operation is forbidden. Money can be transfered only from user to kapper");
         Preconditions.checkArgument(user.getBalance().getAmount().compareTo(amount) >= 0, "The user %s doesnt have enough money. On balance %s",
                 user.getUserName(), user.getBalance());
         try {

--- a/src/main/java/ru/kappers/service/impl/UserServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/UserServiceImpl.java
@@ -206,22 +206,22 @@ public class UserServiceImpl implements UserService {
         log.debug("transfer(user: {}, kapper: {}, amount: {})...", user, kapper, amount);
         Preconditions.checkArgument(user.hasRole("ROLE_USER"), "User %s has no permission to transfer money", user.getUserName());
         Preconditions.checkArgument(kapper.hasRole("ROLE_KAPPER"), "The operation is forbidden. Money can be transfered only from user to kapper");
-        Preconditions.checkArgument(user.getBalance().compareTo(amount) >= 0, "The user %s doesnt have enough money. On balance %s %s",
-                user.getUserName(), user.getBalance(), user.getCurrency());
+        Preconditions.checkArgument(user.getBalance().getAmount().compareTo(amount) >= 0, "The user %s doesnt have enough money. On balance %s",
+                user.getUserName(), user.getBalance());
         try {
-            user.setBalance(user.getBalance().subtract(amount));
-            if (user.getCurrency().equals(kapper.getCurrency())) {
-                kapper.setBalance(kapper.getBalance().add(amount));
-                log.debug("Kapper {} got {} {}", kapper.getUserName(), amount, kapper.getCurrency());
+            user.setBalance(user.getBalance().minus(amount));
+            if (user.getBalance().getCurrencyUnit().equals(kapper.getBalance().getCurrencyUnit())) {
+                kapper.setBalance(kapper.getBalance().plus(amount));
+                log.debug("Kapper {} got {} {}", kapper.getUserName(), amount, kapper.getBalance().getCurrencyUnit());
 
             } else {
-                BigDecimal resultAmount = currencyService.exchange(user.getCurrency(), kapper.getCurrency(), amount);
-                kapper.setBalance(kapper.getBalance().add(resultAmount));
-                log.debug("Kapper {} got {} {}", kapper.getUserName(), resultAmount, kapper.getCurrency());
+                BigDecimal resultAmount = currencyService.exchange(user.getBalance().getCurrencyUnit(), kapper.getBalance().getCurrencyUnit(), amount);
+                kapper.setBalance(kapper.getBalance().plus(resultAmount));
+                log.debug("Kapper {} got {} {}", kapper.getUserName(), resultAmount, kapper.getBalance().getCurrencyUnit());
             }
             editUser(user);
             editUser(kapper);
-            log.info("User {} transfered {} {} to kapper {}", user.getUserName(), amount, user.getCurrency(), kapper.getUserName());
+            log.info("User {} transfered {} {} to kapper {}", user.getUserName(), amount, user.getBalance().getCurrencyUnit(), kapper.getUserName());
         } catch (Exception e) {
             log.error("Couldn't transfer money from {} to {}", user.getUserName(), kapper.getUserName());
             throw new MoneyTransferException(e);

--- a/src/main/resources/public/ui/view/profile/profile.html
+++ b/src/main/resources/public/ui/view/profile/profile.html
@@ -79,7 +79,14 @@
                 <label for="currency" class="col-2 col-form-label">Currency</label>
                 <div class="col-10">
                     <input class="form-control" type="text" id="currency"
-                           ng-model="user.currency" ng-disabled="true">
+                           ng-model="user.balance.currencyUnit.code" ng-disabled="true">
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="balance" class="col-2 col-form-label">Balance</label>
+                <div class="col-10">
+                    <input class="form-control" type="text" id="balance"
+                           ng-model="user.balance.amount" ng-disabled="true">
                 </div>
             </div>
             <div class="form-group row">

--- a/src/test/java/ru/kappers/service/KapperInfoServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/KapperInfoServiceImplTest.java
@@ -1,8 +1,10 @@
 package ru.kappers.service;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
 import lombok.extern.slf4j.Slf4j;
+import org.joda.money.CurrencyUnit;
+import org.joda.money.Money;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,8 +17,11 @@ import org.springframework.test.context.junit4.SpringRunner;
 import ru.kappers.KappersApplication;
 import ru.kappers.exceptions.UserNotHaveKapperRoleException;
 import ru.kappers.model.KapperInfo;
+import ru.kappers.model.Role;
 import ru.kappers.model.User;
 import ru.kappers.util.DateTimeUtil;
+
+import java.math.BigDecimal;
 
 import static org.junit.Assert.*;
 
@@ -34,6 +39,7 @@ public class KapperInfoServiceImplTest extends AbstractTransactionalJUnit4Spring
             .password("assaasas")
             .dateOfBirth(DateTimeUtil.parseTimestampFromDate("1965-08-06+03:00"))
             .lang("RUSSIAN")
+            .balance(Money.of(CurrencyUnit.EUR, new BigDecimal("10.00")))
             .build();
     private User kapper = User.builder()
             .userName("kapper1")
@@ -41,14 +47,22 @@ public class KapperInfoServiceImplTest extends AbstractTransactionalJUnit4Spring
             .password("assaasas")
             .dateOfBirth(DateTimeUtil.parseTimestampFromDate("1965-08-06+03:00"))
             .lang("RUSSIAN")
+            .balance(Money.of(CurrencyUnit.USD, new BigDecimal("100.00")))
             .build();
 
 
     @Autowired
     private KapperInfoService kapperInfoService;
-
     @Autowired
     private UserService userService;
+    @Autowired
+    private RolesService rolesService;
+
+    @Before
+    public void setUp() throws Exception {
+        deleteFromTables("users");
+        kapper.setRole(rolesService.getByName(Role.Names.KAPPER));
+    }
 
     @Test
     public void initKapper() {
@@ -91,6 +105,7 @@ public class KapperInfoServiceImplTest extends AbstractTransactionalJUnit4Spring
         kapper = userService.addUser(kapper);
         user = userService.addUser(user);
 
+        assertNotNull(userService.getByUserName(kapper.getUserName()));
         assertNotNull(kapperInfoService.getByUser(kapper));
         assertNull(kapperInfoService.getByUser(user));
     }

--- a/src/test/java/ru/kappers/service/RoleServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/RoleServiceImplTest.java
@@ -31,25 +31,25 @@ public class RoleServiceImplTest extends AbstractTransactionalJUnit4SpringContex
     public void getRoleNameById() {
         Role roleNameById = rolesService.getById(1);
         Assert.assertNotNull(roleNameById);
-        Assert.assertEquals(roleNameById.getName(), "ROLE_ADMIN");
+        Assert.assertEquals(roleNameById.getName(), Role.Names.ADMIN);
     }
 
     @Test
     public void getRoleIdByName() {
-        int roleId = rolesService.getRoleIdByName("ROLE_USER");
+        int roleId = rolesService.getRoleIdByName(Role.Names.USER);
         Assert.assertEquals(roleId, 2);
     }
 
     @Test
     public void getRoleByName() {
-        Role role = rolesService.getByName("ROLE_USER");
+        Role role = rolesService.getByName(Role.Names.USER);
         Assert.assertEquals(role.getId(), 2);
     }
 
     @Test
     public void getById() {
         Role role = rolesService.getById(2);
-        Assert.assertEquals(role.getName(), "ROLE_USER");
+        Assert.assertEquals(role.getName(), Role.Names.USER);
     }
 
     @Test

--- a/src/test/java/ru/kappers/service/UserServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/UserServiceImplTest.java
@@ -148,7 +148,7 @@ public class UserServiceImplTest extends AbstractTransactionalJUnit4SpringContex
 
     @Test
     public void getAllByRole() {
-        List<User> admins = userService.getAllByRole("ROLE_ADMIN");
+        List<User> admins = userService.getAllByRole(Role.Names.ADMIN);
         assertNotNull(admins);
         assertNotEquals(0, admins.size());
         assertTrue(admins.stream()
@@ -161,13 +161,13 @@ public class UserServiceImplTest extends AbstractTransactionalJUnit4SpringContex
     public void hasRole() {
         User userU = userService.getByUserName(user.getUserName());
         User userK = userService.getByUserName(kapper.getUserName());
-        assertTrue(userService.hasRole(userK, "ROLE_KAPPER"));
-        assertFalse(userService.hasRole(userU, "ROLE_KAPPER"));
-        assertFalse(userService.hasRole(userK, "ROLE_ADMIN"));
-        assertTrue(userService.hasRole(userU, rolesService.getRoleIdByName("ROLE_USER")));
-        assertTrue(userService.hasRole(userU, rolesService.getByName("ROLE_USER")));
+        assertTrue(userService.hasRole(userK, Role.Names.KAPPER));
+        assertFalse(userService.hasRole(userU, Role.Names.KAPPER));
+        assertFalse(userService.hasRole(userK, Role.Names.ADMIN));
+        assertTrue(userService.hasRole(userU, rolesService.getRoleIdByName(Role.Names.USER)));
+        assertTrue(userService.hasRole(userU, rolesService.getByName(Role.Names.USER)));
         assertTrue(userService.hasRole(userU, rolesService.getById(2)));
-        assertEquals(userK.getRole(), rolesService.getByName("ROLE_KAPPER"));
+        assertEquals(userK.getRole(), rolesService.getByName(Role.Names.KAPPER));
     }
 
     @Test
@@ -176,7 +176,7 @@ public class UserServiceImplTest extends AbstractTransactionalJUnit4SpringContex
         assertNotNull(userK);
         Role role = userService.getRole(userK);
         assertNotNull(role);
-        assertEquals(role.getName(), "ROLE_KAPPER");
+        assertEquals(role.getName(), Role.Names.KAPPER);
     }
 
     @Test

--- a/src/test/java/ru/kappers/service/UserServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/UserServiceImplTest.java
@@ -2,7 +2,10 @@ package ru.kappers.service;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
+import org.joda.money.CurrencyUnit;
+import org.joda.money.Money;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,6 +23,7 @@ import ru.kappers.model.User;
 import ru.kappers.repository.UsersRepository;
 import ru.kappers.util.DateTimeUtil;
 
+import java.math.BigDecimal;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -47,6 +51,7 @@ public class UserServiceImplTest extends AbstractTransactionalJUnit4SpringContex
             .password("asasdgfas")
             .dateOfBirth(DateTimeUtil.parseTimestampFromDate("1965-08-06+03:00"))
             .lang("RUSSIAN")
+            .balance(Money.of(CurrencyUnit.EUR, new BigDecimal("10.00")))
             .build();
     private User user = User.builder()
             .userName("user")
@@ -54,6 +59,7 @@ public class UserServiceImplTest extends AbstractTransactionalJUnit4SpringContex
             .password("assaasas")
             .dateOfBirth(DateTimeUtil.parseTimestampFromDate("1965-08-06+03:00"))
             .lang("RUSSIAN")
+            .balance(Money.of(CurrencyUnit.USD, new BigDecimal("10.00")))
             .build();
     private User kapper = User.builder()
             .userName("kapper")
@@ -61,22 +67,20 @@ public class UserServiceImplTest extends AbstractTransactionalJUnit4SpringContex
             .password("assaasas")
             .dateOfBirth(DateTimeUtil.parseTimestampFromDate("1965-08-06+03:00"))
             .lang("RUSSIAN")
+            .balance(Money.of(CurrencyUnit.of("RUB"), new BigDecimal("100.00")))
             .build();
 
-    private final Map<User, Integer> userRoleIdMap = new HashMap<>();
-    {
-        userRoleIdMap.put(admin, 1);
-        userRoleIdMap.put(user, 2);
-        userRoleIdMap.put(kapper, 3);
-    }
+    private final Map<User, String> userRoleNameMap = ImmutableMap.<User, String>builder()
+            .put(admin, Role.Names.ADMIN)
+            .put(user, Role.Names.USER)
+            .put(kapper, Role.Names.KAPPER)
+            .build();
 
     @Before
     public void setUp() {
-        for (User u : userRoleIdMap.keySet()) {
-            if (u.getRole() == null) {
-                u.setRole(rolesService.getById(userRoleIdMap.get(u)));
-            }
-        }
+        userRoleNameMap.entrySet().stream()
+                .filter(it -> it.getKey().getRole() == null)
+                .forEach(it -> it.getKey().setRole(rolesService.getByName(it.getValue())));
     }
 
 

--- a/src/test/resources/data/UserServiceImplTest-users.xml
+++ b/src/test/resources/data/UserServiceImplTest-users.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <dataset>
-    <users user_name="admin" name="админ" password="$2a$04$Ql3ut8yKr4mXdzyUKag0M.yl6/y2c5M1G3ef1/LaVttMdk53dHQ/S" lang="RUSSIAN" role_id="1" currency="RUB"/>
-    <users user_name="user" name="юзер" password="$2a$04$gnmD/AYrURjBwMrHH2FQZO4SNrpEx840o.v7oqEI7oe6riQKKXj66" lang="RUSSIAN" role_id="2" currency="USD"/>
-    <users user_name="kapper" name="каппер" password="$2a$04$r1mkI0Krd1VV3Av5B339zOtOJEyjeCpqISvoec3IgOzpUOnVIRS2C" lang="RUSSIAN" role_id="3" currency="EUR"/>
+    <users user_name="admin" name="админ" password="$2a$04$Ql3ut8yKr4mXdzyUKag0M.yl6/y2c5M1G3ef1/LaVttMdk53dHQ/S" lang="RUSSIAN" role_id="1" currency="RUB" balance="100.15"/>
+    <users user_name="user" name="юзер" password="$2a$04$gnmD/AYrURjBwMrHH2FQZO4SNrpEx840o.v7oqEI7oe6riQKKXj66" lang="RUSSIAN" role_id="2" currency="USD" balance="10.85"/>
+    <users user_name="kapper" name="каппер" password="$2a$04$r1mkI0Krd1VV3Av5B339zOtOJEyjeCpqISvoec3IgOzpUOnVIRS2C" lang="RUSSIAN" role_id="3" currency="EUR" balance="15.55"/>
 </dataset>


### PR DESCRIPTION
### Добавляет поддержку `Joda Money`
- Добавляет менеджмент зависимостей в главный pom.xml и зависимость на `Joda Money`.
- Добавляет закомментированную зависимость на `org.jadira.usertype`. Закомментировано потому что jadira пока ещё не поддерживает `Joda Money` последних версий (версии 1.x и выше) и использует устаревший API.
- Добавляет временный пакет `org.jadira.usertype` с уже доработанными классами и поддержкой `Joda Money` 1.0.1.

### Добавляет константы имен для роли `Role`
Чтобы исключить дальнейшее дублирование строковых констант в класс `Role` добавляется внутренний класс с константами имен `Role.Names`

### Замена типа поля `User.balance` на `org.joda.money.Money`
В JPA-сущности `User` для поля `balance` меняется тип данных на `org.joda.money.Money`.
При этом данные в таблице СУБД хранятся по старому в двух полях.
Также в `User` убирается поле `currency`, а его значение можно теперь узнать через поле `balance`.

Добавление в `CurrencyService` и реализацию метода конвертации суммы из валюты в валюту с учетом нового типа `CurrencyUnit`

Доработан метод перевода денег от пользователя к капперу в `UserServiceImpl` с учетом `Joda Money`

### Доработан личный кабинет в web UI.
Теперь в личном кабинете в web UI выводится валюта и баланс из данный `Joda Money`

Доработаны интеграционные тесты `UserServiceImplTest` и тестовые данные

Доработаны интеграционные тесты `KapperInfoServiceImplTest`
