### PR TITLE
Travis CI and Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ dist: xenial
 
 language: java
 jdk:
-  - openjdk8
+#  - openjdk8
+  - oraclejdk10
 install: true
 before_install:
   - chmod +x mvnw

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,5 @@ script:
   - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
 
 after_success:
+  - bash <(ls -la)
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ script:
   - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
 
 after_success:
+  - $PWD
   - ls -la
-  - cd ./target/reports/jacoco
-  - ls -la
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -s /home/travis/target/reports/jacoco

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ jdk:
 install: true
 before_install:
   - chmod +x mvnw
-#  - ./mvnw --version
-#  - export MAVEN_OPTS="--no-transfer-progress"
 
 # Improve Build Speed https://dzone.com/articles/travis-ci-tutorial-java-projects
 cache:
@@ -30,7 +28,6 @@ before_script:
 
 script:
   - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
-#  - ./mvnw cobertura:cobertura -q -DskipTests=true
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ script:
   - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
 
 after_success:
-  - $PWD
-  - ls -la
+  - $PWD; ls -la
+  - echo "TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR"
   - export JACOCO_REPORT_DIR="$proj_root/target/reports/jacoco"
+  - echo "JACOCO_REPORT_DIR=$JACOCO_REPORT_DIR"
+  - cd $JACOCO_REPORT_DIR; ls -la
   - bash <(curl -s https://codecov.io/bash) -s $JACOCO_REPORT_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 after_success:
   - $PWD; ls -la
   - echo "TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR"
-  - export JACOCO_REPORT_DIR="$proj_root/target/reports/jacoco"
+  - export JACOCO_REPORT_DIR="$TRAVIS_BUILD_DIR/target/reports/jacoco"
   - echo "JACOCO_REPORT_DIR=$JACOCO_REPORT_DIR"
   - cd $JACOCO_REPORT_DIR; ls -la
   - bash <(curl -s https://codecov.io/bash) -s $JACOCO_REPORT_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ script:
   - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
 
 after_success:
-  - bash <(ls -la)
+  - ls -la
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - psql -c 'create database testdb;' -U postgres
 
 script:
-  - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
+  - ./mvnw clean install -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
 
 after_success:
   - $PWD; ls -la

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ after_success:
   - export KAPPER_TARGET_DIR="$TRAVIS_BUILD_DIR/target"
   - echo "KAPPER_TARGET_DIR=$KAPPER_TARGET_DIR"
   - cd $KAPPER_TARGET_DIR; ls -la
-  - export JACOCO_REPORT_DIR="$TRAVIS_BUILD_DIR/target/reports/jacoco"
+  - export JACOCO_REPORT_DIR="$TRAVIS_BUILD_DIR/target/site/jacoco"
   - echo "JACOCO_REPORT_DIR=$JACOCO_REPORT_DIR"
   - cd $JACOCO_REPORT_DIR; ls -la
   - bash <(curl -s https://codecov.io/bash) -s $JACOCO_REPORT_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ os: linux
 dist: xenial
 
 language: java
-#jdk:
-#  - openjdk8
+jdk:
+  - openjdk8
 install: true
 before_install:
   - chmod +x mvnw

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,5 @@ script:
 after_success:
   - $PWD
   - ls -la
-  - bash <(curl -s https://codecov.io/bash) -s /home/travis/target/reports/jacoco
+  - export JACOCO_REPORT_DIR="$proj_root/target/reports/jacoco"
+  - bash <(curl -s https://codecov.io/bash) -s $JACOCO_REPORT_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,6 @@ script:
 
 after_success:
   - ls -la
+  - cd ./target/reports/jacoco
+  - ls -la
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ jdk:
   - openjdk8
 before_install:
   - chmod +x mvnw
-  - ./mvnw --version
+#  - ./mvnw --version
 #  - export MAVEN_OPTS="--no-transfer-progress"
+
+# Improve Build Speed https://dzone.com/articles/travis-ci-tutorial-java-projects
+cache:
+  directories:
+    - $HOME/.m2
 
 addons:
   postgresql: "10"
@@ -24,7 +29,7 @@ before_script:
 
 script:
   - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
-  - ./mvnw cobertura:cobertura -q -DskipTests=true
+#  - ./mvnw cobertura:cobertura -q -DskipTests=true
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,9 @@ before_script:
   - psql -c 'create database testdb;' -U postgres
 
 script:
-  - ./mvnw clean install -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
+  - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
 
 after_success:
-  - $PWD; ls -la
-  - echo "TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR"
   - export KAPPER_TARGET_DIR="$TRAVIS_BUILD_DIR/target"
   - echo "KAPPER_TARGET_DIR=$KAPPER_TARGET_DIR"
   - cd $KAPPER_TARGET_DIR; ls -la

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ before_script:
   - psql -c 'create database testdb;' -U postgres
 
 script:
-  - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
+  - ./mvnw test -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
+#  - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
 #  - ./mvnw cobertura:cobertura -q -DskipTests=true
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ script:
 after_success:
   - $PWD; ls -la
   - echo "TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR"
+  - export KAPPER_TARGET_DIR="$TRAVIS_BUILD_DIR/target"
+  - echo "KAPPER_TARGET_DIR=$KAPPER_TARGET_DIR"
+  - cd $KAPPER_TARGET_DIR; ls -la
   - export JACOCO_REPORT_DIR="$TRAVIS_BUILD_DIR/target/reports/jacoco"
   - echo "JACOCO_REPORT_DIR=$JACOCO_REPORT_DIR"
   - cd $JACOCO_REPORT_DIR; ls -la

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ os: linux
 dist: xenial
 
 language: java
-jdk:
-  - openjdk8
+#jdk:
+#  - openjdk8
+install: true
 before_install:
   - chmod +x mvnw
 #  - ./mvnw --version
@@ -28,8 +29,7 @@ before_script:
   - psql -c 'create database testdb;' -U postgres
 
 script:
-  - ./mvnw test -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
-#  - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
+  - ./mvnw clean install -q -DargLine="-Dspring.datasource.password= -Dspring.jpa.show-sql=false -Dlogging.level.org.flywaydb=warn -Dlogging.level.org.springframework=warn -Dlogging.level.org.springframework.test.context.cache=warn -Dlogging.level.com.github.springtestdbunit=warn -Dlogging.level.org.dbunit.operation=warn -Dlogging.level.org.hibernate.sql=error -Dlogging.level.org.hibernate.type.descriptor.sql.BasicBinder=error -Dlogging.level.org.hibernate.type.EnumType=error"
 #  - ./mvnw cobertura:cobertura -q -DskipTests=true
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ dist: xenial
 
 language: java
 jdk:
-#  - openjdk8
-  - oraclejdk10
+  - openjdk8
 install: true
 before_install:
   - chmod +x mvnw

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,7 @@
                     <executable>true</executable> <!-- позволяет запускать приложение двойным кликом по jar/war-файлу -->
                 </configuration>
             </plugin>
+<!--
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
@@ -260,6 +261,26 @@
                     </formats>
                     <check />
                 </configuration>
+            </plugin>
+-->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,15 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
+                <version>0.8.3</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/KappersApplication.*</exclude>
+                        <exclude>**/ServletInitializer.*</exclude>
+                        <exclude>ru/kappers/config/**/*</exclude>
+                        <exclude>org/jadira/**/*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,8 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.3</version>
                 <configuration>
+                    <!-- outputDirectory сформировал на основе destFile из https://github.com/codecov/example-gradle -->
+                    <outputDirectory>${project.build.directory}/reports/jacoco</outputDirectory>
                     <excludes>
                         <exclude>**/KappersApplication.*</exclude>
                         <exclude>**/ServletInitializer.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -249,17 +249,18 @@
                     <executable>true</executable> <!-- позволяет запускать приложение двойным кликом по jar/war-файлу -->
                 </configuration>
             </plugin>
+<!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-<!--                <version>2.22.1</version>-->
                 <configuration>
                     <forkMode>once</forkMode>
                     <forkCount>1</forkCount>
-                    <argLine>@{argLine} -Xmx1024m </argLine>
+                    <argLine>@{argLine}</argLine>
                     <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
+-->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -280,9 +281,9 @@
                             <goal>prepare-agent</goal>
                         </goals>
 <!--                        http://janejieblog.blogspot.com/2017/12/problem-jacoco-skipping-jacoco.html -->
-<!--                        <configuration>-->
-<!--                            <propertyName>jaCoCoArgLine</propertyName>-->
-<!--                        </configuration>-->
+                        <configuration>
+                            <propertyName>argLine</propertyName>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>report</id>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
+        <argLine></argLine>
     </properties>
 
 <!-- Для централизованного управления зависимостями их версии указываем по возможности только здесь, как и исключения в них -->
@@ -249,18 +250,16 @@
                     <executable>true</executable> <!-- позволяет запускать приложение двойным кликом по jar/war-файлу -->
                 </configuration>
             </plugin>
-<!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkMode>once</forkMode>
                     <forkCount>1</forkCount>
-                    <argLine>@{argLine}</argLine>
+                    <argLine>${argLine} ${jaCoCoArgLine}</argLine>
                     <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
--->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -282,7 +281,7 @@
                         </goals>
 <!--                        http://janejieblog.blogspot.com/2017/12/problem-jacoco-skipping-jacoco.html -->
                         <configuration>
-                            <propertyName>argLine</propertyName>
+                            <propertyName>jaCoCoArgLine</propertyName>
                         </configuration>
                     </execution>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
                 <version>0.8.3</version>
                 <configuration>
                     <!-- outputDirectory сформировал на основе destFile из https://github.com/codecov/example-gradle -->
-                    <outputDirectory>${project.build.directory}/reports/jacoco</outputDirectory>
+<!--                    <outputDirectory>${project.build.directory}/reports/jacoco</outputDirectory>-->
                     <excludes>
                         <exclude>**/KappersApplication.*</exclude>
                         <exclude>**/ServletInitializer.*</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,17 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+<!--                <version>2.22.1</version>-->
+                <configuration>
+                    <forkMode>once</forkMode>
+                    <forkCount>1</forkCount>
+                    <argLine>@{argLine} -Xmx1024m </argLine>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.3</version>
@@ -268,6 +279,10 @@
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+<!--                        http://janejieblog.blogspot.com/2017/12/problem-jacoco-skipping-jacoco.html -->
+<!--                        <configuration>-->
+<!--                            <propertyName>jaCoCoArgLine</propertyName>-->
+<!--                        </configuration>-->
                     </execution>
                     <execution>
                         <id>report</id>

--- a/pom.xml
+++ b/pom.xml
@@ -249,20 +249,6 @@
                     <executable>true</executable> <!-- позволяет запускать приложение двойным кликом по jar/war-файлу -->
                 </configuration>
             </plugin>
-<!--
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <formats>
-                        <format>html</format>
-                        <format>xml</format>
-                    </formats>
-                    <check />
-                </configuration>
-            </plugin>
--->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -10,10 +10,10 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 spring.jpa.open-in-view=false
 
-logging.level.org.springframework=DEBUG
-logging.level.org.springframework.test.context.cache=debug
-logging.level.com.github.springtestdbunit=debug
-logging.level.org.dbunit.operation=debug
+logging.level.org.springframework=info
+logging.level.org.springframework.test.context.cache=info
+logging.level.com.github.springtestdbunit=info
+logging.level.org.dbunit.operation=info
 logging.level.org.hibernate.sql=debug
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=trace
 logging.level.org.hibernate.type.EnumType=trace


### PR DESCRIPTION
Доработана интеграция с Travis CI и Codecov
- Добавлен файл настроек `codecov.yml` для Codecov
- Доработан файл настроек `.travis.yml` для Travis CI
- Добавлен файл настроек `lombok.config` для Lombok
- В тестах для некоторых пакетов уровень логирования изменен на `INFO`
- Вместо плагина `cobertura-maven-plugin` теперь используется плагин `jacoco-maven-plugin` для построения отчета о покрытии кода тестами. Из подсчета исключены ряд классов и пакетов, а также генерируемый код из Lombok.
- Добавлена явная настройка плагина `maven-surefire-plugin`, т.к. на виртуальной машине в Travic CI при сборке плагин `jacoco-maven-plugin` не строил отчет.

Пример настроенной интеграции для клона данного PR можно посмотреть здесь: https://github.com/SuleymanovRA/kappers/pull/2