### PR TITLE
Рефакторинг JPA-сущностей и сервисов Leon

### DIFF
--- a/src/main/java/ru/kappers/config/WebAppConfig.java
+++ b/src/main/java/ru/kappers/config/WebAppConfig.java
@@ -22,6 +22,8 @@ import ru.kappers.model.dto.rapidapi.LeagueRapidDTO;
 import ru.kappers.model.dto.rapidapi.TeamRapidDTO;
 import ru.kappers.model.leonmodels.*;
 
+import java.util.List;
+
 @Configuration
 public class WebAppConfig implements WebMvcConfigurer {
 
@@ -32,6 +34,8 @@ public class WebAppConfig implements WebMvcConfigurer {
     private Converter<CompetitorLeonDTO, CompetitorLeon> competitorLeonDTOCompetitorLeonConverter;
     private Converter<LeagueLeonDTO, LeagueLeon> leagueLeonDTOLeagueLeonConverter;
     private Converter<OddsLeonDTO, OddsLeon> oddsLeonDTOOddsLeonConverter;
+    private Converter<MarketLeonDTO, MarketLeon> marketLeonDTOToMarketLeonConverter;
+    private Converter<MarketLeonDTO, List<RunnerLeon>> marketLeonDTOToRunnerLeonListConverter;
 
     private KappersProperties kappersProperties;
 
@@ -76,6 +80,16 @@ public class WebAppConfig implements WebMvcConfigurer {
         this.oddsLeonDTOOddsLeonConverter = oddsLeonDTOOddsLeonConverter;
     }
 
+    @Autowired
+    public void setMarketLeonDTOToMarketLeonConverter(Converter<MarketLeonDTO, MarketLeon> marketLeonDTOToMarketLeonConverter) {
+        this.marketLeonDTOToMarketLeonConverter = marketLeonDTOToMarketLeonConverter;
+    }
+
+    @Autowired
+    public void setMarketLeonDTOToRunnerLeonListConverter(Converter<MarketLeonDTO, List<RunnerLeon>> marketLeonDTOToRunnerLeonListConverter) {
+        this.marketLeonDTOToRunnerLeonListConverter = marketLeonDTOToRunnerLeonListConverter;
+    }
+
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(fixtureRapidDTOFixtureConverter);
@@ -85,6 +99,8 @@ public class WebAppConfig implements WebMvcConfigurer {
         registry.addConverter(competitorLeonDTOCompetitorLeonConverter);
         registry.addConverter(leagueLeonDTOLeagueLeonConverter);
         registry.addConverter(oddsLeonDTOOddsLeonConverter);
+        registry.addConverter(marketLeonDTOToMarketLeonConverter);
+        registry.addConverter(marketLeonDTOToRunnerLeonListConverter);
     }
 
     @Override

--- a/src/main/java/ru/kappers/convert/CompetitorLeonDTOToCompetitorLeonConverter.java
+++ b/src/main/java/ru/kappers/convert/CompetitorLeonDTOToCompetitorLeonConverter.java
@@ -12,14 +12,13 @@ public class CompetitorLeonDTOToCompetitorLeonConverter implements Converter<Com
     @Nullable
     @Override
     public CompetitorLeon convert(@Nullable CompetitorLeonDTO source) {
-        if (source==null)
-        return null;
-        else{
-           return CompetitorLeon.builder()
-                   .id(source.getId())
-                   .logo(source.getLogo())
-                   .name(source.getName())
-                   .build();
+        if (source == null) {
+            return null;
         }
+        return CompetitorLeon.builder()
+                .id(source.getId())
+                .logo(source.getLogo())
+                .name(source.getName())
+                .build();
     }
 }

--- a/src/main/java/ru/kappers/convert/LeagueLeonDTOToLeagueLeonConverter.java
+++ b/src/main/java/ru/kappers/convert/LeagueLeonDTOToLeagueLeonConverter.java
@@ -14,15 +14,14 @@ public class LeagueLeonDTOToLeagueLeonConverter implements Converter<LeagueLeonD
     @Nullable
     @Override
     public LeagueLeon convert(@Nullable LeagueLeonDTO source) {
-        if (source == null)
+        if (source == null) {
             return null;
-        else {
-            return LeagueLeon.builder()
-                    .id(source.getId())
-                    .name(source.getName())
-                    .url(source.getUrl())
-                    .sport(source.getSport().getName())
-                    .build();
         }
+        return LeagueLeon.builder()
+                .id(source.getId())
+                .name(source.getName())
+                .url(source.getUrl())
+                .sport(source.getSport().getName())
+                .build();
     }
 }

--- a/src/main/java/ru/kappers/convert/MarketLeonDTOToMarketLeonConverter.java
+++ b/src/main/java/ru/kappers/convert/MarketLeonDTOToMarketLeonConverter.java
@@ -1,0 +1,26 @@
+package ru.kappers.convert;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Service;
+import ru.kappers.model.dto.leon.MarketLeonDTO;
+import ru.kappers.model.leonmodels.MarketLeon;
+
+import javax.annotation.Nullable;
+
+@Slf4j
+@Service
+public class MarketLeonDTOToMarketLeonConverter implements Converter<MarketLeonDTO, MarketLeon> {
+    @Nullable
+    @Override
+    public MarketLeon convert(@Nullable MarketLeonDTO source) {
+        if (source == null) {
+            return null;
+        }
+        return MarketLeon.builder()
+                .id(source.getId())
+                .name(source.getName())
+                .open(source.isOpen())
+                .build();
+    }
+}

--- a/src/main/java/ru/kappers/convert/MarketLeonDTOToRunnerLeonListConverter.java
+++ b/src/main/java/ru/kappers/convert/MarketLeonDTOToRunnerLeonListConverter.java
@@ -1,0 +1,57 @@
+package ru.kappers.convert;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Service;
+import ru.kappers.model.dto.leon.MarketLeonDTO;
+import ru.kappers.model.dto.leon.RunnerLeonDTO;
+import ru.kappers.model.leonmodels.MarketLeon;
+import ru.kappers.model.leonmodels.RunnerLeon;
+import ru.kappers.service.MarketLeonService;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+public class MarketLeonDTOToRunnerLeonListConverter implements Converter<MarketLeonDTO, List<RunnerLeon>> {
+    private final MarketLeonService marketService;
+    private final ConversionService conversionService;
+
+    @Autowired
+    public MarketLeonDTOToRunnerLeonListConverter(MarketLeonService marketService, @Lazy ConversionService conversionService) {
+        this.marketService = marketService;
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    public List<RunnerLeon> convert(@Nullable MarketLeonDTO source) {
+        if (source == null) {
+            return new ArrayList<>();
+        }
+        final MarketLeonDTO marketDTO = source;
+        final List<RunnerLeon> runners = new ArrayList<>(marketDTO.getRunners().size());
+
+        MarketLeon market = marketService.getByName(marketDTO.getName());
+        if (market == null) {
+            market = marketService.save(conversionService.convert(marketDTO, MarketLeon.class));
+        }
+
+        for (RunnerLeonDTO runnerDTO : marketDTO.getRunners()) {
+            runners.add(RunnerLeon.builder()
+                    .id(runnerDTO.getId())
+                    .name(runnerDTO.getName())
+                    .price(runnerDTO.getPrice())
+                    .open(runnerDTO.isOpen())
+                    .market(market)
+                    .tags(runnerDTO.getTags().toString())
+                    .build()
+            );
+        }
+        return runners;
+    }
+}

--- a/src/main/java/ru/kappers/model/leonmodels/CompetitorLeon.java
+++ b/src/main/java/ru/kappers/model/leonmodels/CompetitorLeon.java
@@ -32,8 +32,12 @@ public class CompetitorLeon  {
     private String logo;
 
     @OneToMany (mappedBy = "home")
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     private List<OddsLeon> home_odds;
 
     @OneToMany (mappedBy = "away")
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     private List<OddsLeon> away_odds;
 }

--- a/src/main/java/ru/kappers/service/impl/CompetitorLeonServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/CompetitorLeonServiceImpl.java
@@ -12,9 +12,12 @@ import java.util.List;
 @Slf4j
 @Service
 public class CompetitorLeonServiceImpl implements CompetitorLeonService {
+    private final CompetitorRepository repository;
 
     @Autowired
-    CompetitorRepository repository;
+    public CompetitorLeonServiceImpl(CompetitorRepository repository) {
+        this.repository = repository;
+    }
 
     @Override
     public CompetitorLeon save(CompetitorLeon comp) {

--- a/src/main/java/ru/kappers/service/impl/CompetitorLeonServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/CompetitorLeonServiceImpl.java
@@ -3,6 +3,7 @@ package ru.kappers.service.impl;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ru.kappers.model.leonmodels.CompetitorLeon;
 import ru.kappers.repository.CompetitorRepository;
 import ru.kappers.service.CompetitorLeonService;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Slf4j
 @Service
+@Transactional
 public class CompetitorLeonServiceImpl implements CompetitorLeonService {
     private final CompetitorRepository repository;
 
@@ -35,16 +37,19 @@ public class CompetitorLeonServiceImpl implements CompetitorLeonService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public CompetitorLeon getById(long compId) {
         return repository.getOne(compId);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<CompetitorLeon> getAll() {
         return repository.findAll();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public CompetitorLeon getByName(String name) {
         return repository.getByName(name);
     }

--- a/src/main/java/ru/kappers/service/impl/LeagueLeonServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/LeagueLeonServiceImpl.java
@@ -3,12 +3,14 @@ package ru.kappers.service.impl;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ru.kappers.model.leonmodels.LeagueLeon;
 import ru.kappers.repository.LeagueLeonRepository;
 import ru.kappers.service.LeagueLeonService;
 
 @Service
 @Slf4j
+@Transactional
 public class LeagueLeonServiceImpl implements LeagueLeonService {
     private final LeagueLeonRepository repository;
 
@@ -18,6 +20,7 @@ public class LeagueLeonServiceImpl implements LeagueLeonService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public LeagueLeon getByName(String name) {
         return repository.getByName(name);
     }

--- a/src/main/java/ru/kappers/service/impl/LeagueLeonServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/LeagueLeonServiceImpl.java
@@ -10,8 +10,13 @@ import ru.kappers.service.LeagueLeonService;
 @Service
 @Slf4j
 public class LeagueLeonServiceImpl implements LeagueLeonService {
+    private final LeagueLeonRepository repository;
+
     @Autowired
-    LeagueLeonRepository repository;
+    public LeagueLeonServiceImpl(LeagueLeonRepository repository) {
+        this.repository = repository;
+    }
+
     @Override
     public LeagueLeon getByName(String name) {
         return repository.getByName(name);

--- a/src/main/java/ru/kappers/service/impl/MarketLeonServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/MarketLeonServiceImpl.java
@@ -3,6 +3,7 @@ package ru.kappers.service.impl;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ru.kappers.model.leonmodels.MarketLeon;
 import ru.kappers.repository.MarketLeonRepository;
 import ru.kappers.service.MarketLeonService;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Service
 @Slf4j
+@Transactional
 public class MarketLeonServiceImpl implements MarketLeonService {
     private final MarketLeonRepository repository;
 
@@ -20,16 +22,19 @@ public class MarketLeonServiceImpl implements MarketLeonService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public MarketLeon getByName(String name) {
         return repository.getByName(name);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public MarketLeon getById(long id) {
         return repository.getOne(id);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<MarketLeon> getAll() {
         return repository.findAll();
     }

--- a/src/main/java/ru/kappers/service/impl/OddsLeonServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/OddsLeonServiceImpl.java
@@ -14,10 +14,10 @@ import java.util.List;
 @Service
 @Transactional
 public class OddsLeonServiceImpl implements OddsLeonService {
-    private OddsLeonRepository repository;
+    private final OddsLeonRepository repository;
 
     @Autowired
-    public void setRepository(OddsLeonRepository repository) {
+    public OddsLeonServiceImpl(OddsLeonRepository repository) {
         this.repository = repository;
     }
 
@@ -37,11 +37,13 @@ public class OddsLeonServiceImpl implements OddsLeonService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public OddsLeon getById(long oddId) {
         return repository.getOne(oddId);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<OddsLeon> getAll() {
         return repository.findAll();
     }

--- a/src/main/java/ru/kappers/service/impl/RunnerLeonServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/RunnerLeonServiceImpl.java
@@ -10,8 +10,8 @@ import ru.kappers.service.MarketLeonService;
 import ru.kappers.service.OddsLeonService;
 import ru.kappers.service.RunnerLeonService;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -69,10 +69,8 @@ public class RunnerLeonServiceImpl implements RunnerLeonService {
 
     @Override
     public List<RunnerLeon> saveAll(List<RunnerLeon> runners) {
-        List<RunnerLeon> savedOnes = new ArrayList<>();
-        for (RunnerLeon r:runners) {
-            savedOnes.add(repository.save(r));
-        }
-       return savedOnes;
+       return runners.stream()
+               .map(repository::save)
+               .collect(Collectors.toList());
     }
 }

--- a/src/main/java/ru/kappers/service/impl/RunnerLeonServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/RunnerLeonServiceImpl.java
@@ -3,6 +3,7 @@ package ru.kappers.service.impl;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import ru.kappers.model.leonmodels.RunnerLeon;
 import ru.kappers.repository.RunnerLeonRepository;
 import ru.kappers.service.MarketLeonService;
@@ -14,6 +15,7 @@ import java.util.List;
 
 @Service
 @Slf4j
+@Transactional
 public class RunnerLeonServiceImpl implements RunnerLeonService {
     private final RunnerLeonRepository repository;
     private final MarketLeonService marketService;
@@ -27,16 +29,19 @@ public class RunnerLeonServiceImpl implements RunnerLeonService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<RunnerLeon> getByMarketAndOdd(long marketId, long oddId) {
         return repository.getByMarketAndOdd(marketService.getById(marketId), oddService.getById(oddId));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<RunnerLeon> getByOdd(long oddId) {
         return repository.getByOdd(oddService.getById(oddId));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<RunnerLeon> getAll() {
         return repository.findAll();
     }
@@ -52,6 +57,7 @@ public class RunnerLeonServiceImpl implements RunnerLeonService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public RunnerLeon getById(long id) {
         return repository.getOne(id);
     }

--- a/src/test/java/ru/kappers/convert/CompetitorLeonDTOToCompetitorLeonConverterTest.java
+++ b/src/test/java/ru/kappers/convert/CompetitorLeonDTOToCompetitorLeonConverterTest.java
@@ -1,0 +1,50 @@
+package ru.kappers.convert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import ru.kappers.model.dto.leon.CompetitorLeonDTO;
+import ru.kappers.model.leonmodels.CompetitorLeon;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CompetitorLeonDTOToCompetitorLeonConverterTest {
+    @InjectMocks
+    private CompetitorLeonDTOToCompetitorLeonConverter converter;
+
+    @Test
+    public void convertMustReturnNullIfParameterIsNull() {
+        assertThat(converter.convert(null), is(nullValue()));
+    }
+
+    @Test
+    public void convert() {
+        List<CompetitorLeonDTO> dtoList = Arrays.asList(
+                CompetitorLeonDTO.builder()
+                        .id(1L)
+                        .logo("http://test1.jpg")
+                        .name("test name1")
+                        .build(),
+                CompetitorLeonDTO.builder()
+                        .id(2L)
+                        .logo("http://test2.jpg")
+                        .name("test name2")
+                        .build()
+        );
+
+        for (CompetitorLeonDTO dto : dtoList) {
+            final CompetitorLeon result = converter.convert(dto);
+
+            assertThat(result, is(notNullValue()));
+            assertThat(result.getId(), is(dto.getId()));
+            assertThat(result.getLogo(), is(dto.getLogo()));
+            assertThat(result.getName(), is(dto.getName()));
+        }
+    }
+}

--- a/src/test/java/ru/kappers/convert/LeagueLeonDTOToLeagueLeonConverterTest.java
+++ b/src/test/java/ru/kappers/convert/LeagueLeonDTOToLeagueLeonConverterTest.java
@@ -1,0 +1,58 @@
+package ru.kappers.convert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import ru.kappers.model.dto.leon.LeagueLeonDTO;
+import ru.kappers.model.dto.leon.SportLeonDTO;
+import ru.kappers.model.leonmodels.LeagueLeon;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LeagueLeonDTOToLeagueLeonConverterTest {
+    @InjectMocks
+    private LeagueLeonDTOToLeagueLeonConverter converter;
+
+    @Test
+    public void convertMustReturnNullIfParameterIsNull() {
+        assertThat(converter.convert(null), is(nullValue()));
+    }
+
+    @Test
+    public void convert() {
+        final List<LeagueLeonDTO> dtoList = Arrays.asList(
+                LeagueLeonDTO.builder()
+                        .id(1L)
+                        .name("test name1")
+                        .url("http://url1/")
+                        .sport(SportLeonDTO.builder()
+                                .name("test sport name1")
+                                .build())
+                        .build(),
+                LeagueLeonDTO.builder()
+                        .id(2L)
+                        .name("test name2")
+                        .url("http://url2/")
+                        .sport(SportLeonDTO.builder()
+                                .name("test sport name2")
+                                .build())
+                        .build()
+        );
+
+        for (LeagueLeonDTO dto : dtoList) {
+            final LeagueLeon result = converter.convert(dto);
+
+            assertThat(result, is(notNullValue()));
+            assertThat(result.getId(), is(dto.getId()));
+            assertThat(result.getName(), is(dto.getName()));
+            assertThat(result.getUrl(), is(dto.getUrl()));
+            assertThat(result.getSport(), is(dto.getSport().getName()));
+        }
+    }
+}

--- a/src/test/java/ru/kappers/convert/MarketLeonDTOToMarketLeonConverterTest.java
+++ b/src/test/java/ru/kappers/convert/MarketLeonDTOToMarketLeonConverterTest.java
@@ -1,0 +1,51 @@
+package ru.kappers.convert;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import ru.kappers.model.dto.leon.MarketLeonDTO;
+import ru.kappers.model.leonmodels.MarketLeon;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MarketLeonDTOToMarketLeonConverterTest {
+    @InjectMocks
+    private MarketLeonDTOToMarketLeonConverter converter;
+
+    @Test
+    public void convertMustReturnNullIfParameterIsNull() {
+        assertThat(converter.convert(null), is(nullValue()));
+    }
+
+    @Test
+    public void convert() {
+        final List<MarketLeonDTO> dtoList = Arrays.asList(
+                MarketLeonDTO.builder()
+                        .id(1L)
+                        .name("name 1")
+                        .open(true)
+                        .build(),
+                MarketLeonDTO.builder()
+                        .id(2L)
+                        .name("name 2")
+                        .open(false)
+                        .build()
+        );
+
+        for (MarketLeonDTO dto : dtoList) {
+            final MarketLeon result = converter.convert(dto);
+
+            assertThat(result, is(notNullValue()));
+            assertThat(result.getId(), is(dto.getId()));
+            assertThat(result.getName(), is(dto.getName()));
+            assertThat(result.isOpen(), is(dto.isOpen()));
+        }
+    }
+}

--- a/src/test/java/ru/kappers/convert/MarketLeonDTOToRunnerLeonListConverterTest.java
+++ b/src/test/java/ru/kappers/convert/MarketLeonDTOToRunnerLeonListConverterTest.java
@@ -1,0 +1,34 @@
+package ru.kappers.convert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.convert.ConversionService;
+import ru.kappers.model.leonmodels.RunnerLeon;
+import ru.kappers.service.MarketLeonService;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MarketLeonDTOToRunnerLeonListConverterTest {
+    @InjectMocks
+    private MarketLeonDTOToRunnerLeonListConverter converter;
+    @Mock
+    private MarketLeonService marketService;
+    @Mock
+    private ConversionService conversionService;
+
+    @Test
+    public void convertMustReturnImptyListIfParameterIsNull() {
+        final List<RunnerLeon> result = converter.convert(null);
+
+        assertThat(result, is(notNullValue()));
+        assertThat(result.size(), is(0));
+    }
+}

--- a/src/test/java/ru/kappers/convert/OddsLeonDTOToOddsLeonConverterTest.java
+++ b/src/test/java/ru/kappers/convert/OddsLeonDTOToOddsLeonConverterTest.java
@@ -1,0 +1,121 @@
+package ru.kappers.convert;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.convert.ConversionService;
+import ru.kappers.model.dto.leon.CompetitorLeonDTO;
+import ru.kappers.model.dto.leon.LeagueLeonDTO;
+import ru.kappers.model.dto.leon.OddsLeonDTO;
+import ru.kappers.model.leonmodels.CompetitorLeon;
+import ru.kappers.model.leonmodels.LeagueLeon;
+import ru.kappers.model.leonmodels.OddsLeon;
+import ru.kappers.service.CompetitorLeonService;
+import ru.kappers.service.LeagueLeonService;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OddsLeonDTOToOddsLeonConverterTest {
+    @InjectMocks
+    private OddsLeonDTOToOddsLeonConverter converter;
+    @Mock
+    private CompetitorLeonService competitorService;
+    @Mock
+    private LeagueLeonService leagueService;
+    @Mock
+    private ConversionService conversionService;
+
+    @Test
+    public void convertMustReturnNullIfParameterIsNull() {
+        assertThat(converter.convert(null), is(nullValue()));
+    }
+
+    @Test
+    public void convert() {
+        final String compName1 = "Участник 1";
+        final String compName2 = "Участник 2";
+        final CompetitorLeon competitor1 = mock(CompetitorLeon.class);
+        final CompetitorLeon competitor2 = mock(CompetitorLeon.class);
+        final LeagueLeon league = mock(LeagueLeon.class);
+        final List<CompetitorLeonDTO> competitorLeonDTOList = Arrays.asList(
+                CompetitorLeonDTO.builder()
+                        .name(compName1)
+                        .homeAway("HOME")
+                        .build(),
+                CompetitorLeonDTO.builder()
+                        .name(compName2)
+                        .homeAway("AWAY")
+                        .build()
+        );
+        final LeagueLeonDTO leagueLeonDTO = LeagueLeonDTO.builder().
+                name("League 1")
+                .build();
+
+        final List<OddsLeonDTO> dtoList = Arrays.asList(
+                OddsLeonDTO.builder()
+                        .competitors(competitorLeonDTOList)
+                        .league(leagueLeonDTO)
+                        .id(1L)
+                        .name("odd 1")
+                        .kickoff(1L)
+                        .open(true)
+                        .url("http://url1/")
+                        .lastUpdated(100L)
+                        .build(),
+                OddsLeonDTO.builder()
+                        .competitors(competitorLeonDTOList)
+                        .league(leagueLeonDTO)
+                        .id(2L)
+                        .name("odd 2")
+                        .kickoff(10L)
+                        .open(true)
+                        .url("http://url2/")
+                        .lastUpdated(1000L)
+                        .build()
+        );
+
+        for (OddsLeonDTO dto : dtoList) {
+            reset(competitorService, conversionService, leagueService);
+            when(competitorService.save(any())).thenAnswer(it -> it.getArgument(0));
+            when(conversionService.convert(any(CompetitorLeonDTO.class), eq(CompetitorLeon.class))).thenAnswer(it -> {
+                CompetitorLeonDTO dtoInner = it.getArgument(0);
+                return dtoInner.getName().equals(compName1) ? competitor1 : competitor2;
+            });
+            when(leagueService.save(any())).thenAnswer(it -> it.getArgument(0));
+            when(conversionService.convert(any(LeagueLeonDTO.class), eq(LeagueLeon.class))).thenReturn(league);
+
+            final OddsLeon result = converter.convert(dto);
+
+            assertThat(result, is(notNullValue()));
+            assertThat(result.getId(), is(dto.getId()));
+            assertThat(result.getName(), is(dto.getName()));
+            assertThat(result.getKickoff(), is(new Timestamp(dto.getKickoff())));
+            assertThat(result.isOpen(), is(dto.isOpen()));
+            assertThat(result.getUrl(), is(dto.getUrl()));
+            assertThat(result.getLastUpdated(), is(new Timestamp(dto.getLastUpdated())));
+            assertThat(result.getLeague(), is(league));
+            assertThat(result.getHome(), is(competitor1));
+            assertThat(result.getAway(), is(competitor2));
+            assertThat(result.getRunners(), is(notNullValue()));
+            verify(competitorService).getByName(compName1);
+            verify(competitorService).getByName(compName2);
+            verify(conversionService, times(competitorLeonDTOList.size())).convert(any(CompetitorLeonDTO.class), eq(CompetitorLeon.class));
+            verify(competitorService, times(competitorLeonDTOList.size())).save(any());
+            verify(leagueService).getByName(eq(dto.getLeague().getName()));
+            verify(conversionService).convert(any(LeagueLeonDTO.class), eq(LeagueLeon.class));
+            verify(leagueService).save(any());
+        }
+    }
+}

--- a/src/test/java/ru/kappers/service/impl/CompetitorLeonServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/impl/CompetitorLeonServiceImplTest.java
@@ -1,0 +1,90 @@
+package ru.kappers.service.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import ru.kappers.model.leonmodels.CompetitorLeon;
+import ru.kappers.repository.CompetitorRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CompetitorLeonServiceImplTest {
+    @InjectMocks
+    private CompetitorLeonServiceImpl competitorLeonService;
+    @Mock
+    private CompetitorRepository repository;
+
+    @Test
+    public void save() {
+        final CompetitorLeon competitor = mock(CompetitorLeon.class);
+        when(repository.save(competitor)).thenReturn(competitor);
+
+        final CompetitorLeon result = competitorLeonService.save(competitor);
+
+        assertThat(result, is(competitor));
+        verify(repository).save(competitor);
+    }
+
+    @Test
+    public void delete() {
+        final CompetitorLeon competitor = mock(CompetitorLeon.class);
+
+        competitorLeonService.delete(competitor);
+
+        verify(repository).delete(competitor);
+    }
+
+    @Test
+    public void update() {
+        final CompetitorLeon competitor = mock(CompetitorLeon.class);
+        when(repository.save(competitor)).thenReturn(competitor);
+
+        final CompetitorLeon result = competitorLeonService.update(competitor);
+
+        assertThat(result, is(competitor));
+        verify(repository).save(competitor);
+    }
+
+    @Test
+    public void getById() {
+        final long id = 1L;
+        final CompetitorLeon competitor = mock(CompetitorLeon.class);
+        when(repository.getOne(id)).thenReturn(competitor);
+
+        final CompetitorLeon result = competitorLeonService.getById(id);
+
+        assertThat(result, is(competitor));
+        verify(repository).getOne(id);
+    }
+
+    @Test
+    public void getAll() {
+        final List<CompetitorLeon> competitorLeonList = Arrays.asList(mock(CompetitorLeon.class), mock(CompetitorLeon.class));
+        when(repository.findAll()).thenReturn(competitorLeonList);
+
+        final List<CompetitorLeon> result = competitorLeonService.getAll();
+
+        assertThat(result, is(competitorLeonList));
+        verify(repository).findAll();
+    }
+
+    @Test
+    public void getByName() {
+        final String name = "test name";
+        final CompetitorLeon competitor = mock(CompetitorLeon.class);
+        when(repository.getByName(name)).thenReturn(competitor);
+
+        final CompetitorLeon result = competitorLeonService.getByName(name);
+
+        assertThat(result, is(competitor));
+        verify(repository).getByName(name);
+    }
+}

--- a/src/test/java/ru/kappers/service/impl/LeagueLeonServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/impl/LeagueLeonServiceImplTest.java
@@ -1,0 +1,44 @@
+package ru.kappers.service.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import ru.kappers.model.leonmodels.LeagueLeon;
+import ru.kappers.repository.LeagueLeonRepository;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LeagueLeonServiceImplTest {
+    @InjectMocks
+    private LeagueLeonServiceImpl leagueLeonService;
+    @Mock
+    private LeagueLeonRepository repository;
+
+    @Test
+    public void getByName() {
+        final String name = "test Name";
+        final LeagueLeon leagueLeon = mock(LeagueLeon.class);
+        when(repository.getByName(name)).thenReturn(leagueLeon);
+
+        final LeagueLeon result = leagueLeonService.getByName(name);
+
+        assertThat(result, is(leagueLeon));
+        verify(repository).getByName(name);
+    }
+
+    @Test
+    public void save() {
+        final LeagueLeon leagueLeon = mock(LeagueLeon.class);
+        when(repository.save(leagueLeon)).thenReturn(leagueLeon);
+
+        final LeagueLeon result = leagueLeonService.save(leagueLeon);
+
+        assertThat(result, is(leagueLeon));
+        verify(repository).save(leagueLeon);
+    }
+}

--- a/src/test/java/ru/kappers/service/impl/MarketLeonServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/impl/MarketLeonServiceImplTest.java
@@ -1,0 +1,70 @@
+package ru.kappers.service.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import ru.kappers.model.leonmodels.MarketLeon;
+import ru.kappers.repository.MarketLeonRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MarketLeonServiceImplTest {
+    @InjectMocks
+    private MarketLeonServiceImpl marketLeonService;
+    @Mock
+    private MarketLeonRepository repository;
+
+    @Test
+    public void getByName() {
+        final String name = "test name";
+        final MarketLeon marketLeon = mock(MarketLeon.class);
+        when(repository.getByName(name)).thenReturn(marketLeon);
+
+        final MarketLeon result = marketLeonService.getByName(name);
+
+        assertThat(result, is(marketLeon));
+        verify(repository).getByName(name);
+    }
+
+    @Test
+    public void getById() {
+        final long id = 1L;
+        final MarketLeon marketLeon = mock(MarketLeon.class);
+        when(repository.getOne(id)).thenReturn(marketLeon);
+
+        final MarketLeon result = marketLeonService.getById(id);
+
+        assertThat(result, is(marketLeon));
+        verify(repository).getOne(id);
+    }
+
+    @Test
+    public void getAll() {
+        List<MarketLeon> marketLeonList = Arrays.asList(mock(MarketLeon.class), mock(MarketLeon.class));
+        when(repository.findAll()).thenReturn(marketLeonList);
+
+        final List<MarketLeon> result = marketLeonService.getAll();
+
+        assertThat(result, is(marketLeonList));
+        verify(repository).findAll();
+    }
+
+    @Test
+    public void save() {
+        final MarketLeon marketLeon = mock(MarketLeon.class);
+        when(repository.save(marketLeon)).thenReturn(marketLeon);
+
+        final MarketLeon result = marketLeonService.save(marketLeon);
+
+        assertThat(result, is(marketLeon));
+        verify(repository).save(marketLeon);
+    }
+}

--- a/src/test/java/ru/kappers/service/impl/OddsLeonServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/impl/OddsLeonServiceImplTest.java
@@ -1,0 +1,80 @@
+package ru.kappers.service.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import ru.kappers.model.leonmodels.OddsLeon;
+import ru.kappers.repository.OddsLeonRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OddsLeonServiceImplTest {
+    @InjectMocks
+    private OddsLeonServiceImpl oddsLeonService;
+    @Mock
+    private OddsLeonRepository repository;
+
+    @Test
+    public void save() {
+        final OddsLeon odd = mock(OddsLeon.class);
+        when(repository.save(odd)).thenReturn(odd);
+
+        final OddsLeon result = oddsLeonService.save(odd);
+
+        assertThat(result, is(odd));
+        verify(repository).save(odd);
+    }
+
+    @Test
+    public void delete() {
+        final OddsLeon odd = mock(OddsLeon.class);
+
+        oddsLeonService.delete(odd);
+
+        verify(repository).delete(odd);
+    }
+
+    @Test
+    public void update() {
+        final OddsLeon odd = mock(OddsLeon.class);
+        when(repository.save(odd)).thenReturn(odd);
+        oddsLeonService = spy(oddsLeonService);
+
+        final OddsLeon result = oddsLeonService.update(odd);
+
+        assertThat(result, is(odd));
+        verify(oddsLeonService).save(odd);
+        verify(repository).save(odd);
+    }
+
+    @Test
+    public void getById() {
+        final long id = 1L;
+        final OddsLeon odd = mock(OddsLeon.class);
+        when(repository.getOne(id)).thenReturn(odd);
+
+        final OddsLeon result = oddsLeonService.getById(id);
+
+        assertThat(result, is(odd));
+        verify(repository).getOne(id);
+    }
+
+    @Test
+    public void getAll() {
+        final List<OddsLeon> oddsLeonList = Arrays.asList(mock(OddsLeon.class), mock(OddsLeon.class));
+        when(repository.findAll()).thenReturn(oddsLeonList);
+
+        final List<OddsLeon> result = oddsLeonService.getAll();
+
+        assertThat(result, is(oddsLeonList));
+        verify(repository).findAll();
+    }
+}

--- a/src/test/java/ru/kappers/service/impl/RunnerLeonServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/impl/RunnerLeonServiceImplTest.java
@@ -1,0 +1,132 @@
+package ru.kappers.service.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import ru.kappers.model.leonmodels.MarketLeon;
+import ru.kappers.model.leonmodels.OddsLeon;
+import ru.kappers.model.leonmodels.RunnerLeon;
+import ru.kappers.repository.RunnerLeonRepository;
+import ru.kappers.service.MarketLeonService;
+import ru.kappers.service.OddsLeonService;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RunnerLeonServiceImplTest {
+    @InjectMocks
+    private RunnerLeonServiceImpl runnerLeonService;
+    @Mock
+    private RunnerLeonRepository repository;
+    @Mock
+    private MarketLeonService marketService;
+    @Mock
+    private OddsLeonService oddService;
+
+    @Test
+    public void getByMarketAndOdd() {
+        final long marketId = 1L;
+        final long oddId = 2L;
+        final MarketLeon market = mock(MarketLeon.class);
+        final OddsLeon odd = mock(OddsLeon.class);
+        final List<RunnerLeon> runnerLeonList = Arrays.asList(mock(RunnerLeon.class), mock(RunnerLeon.class));
+        when(marketService.getById(marketId)).thenReturn(market);
+        when(oddService.getById(oddId)).thenReturn(odd);
+        when(repository.getByMarketAndOdd(market, odd)).thenReturn(runnerLeonList);
+
+        final List<RunnerLeon> result = runnerLeonService.getByMarketAndOdd(marketId, oddId);
+
+        assertThat(result, is(runnerLeonList));
+        verify(marketService).getById(marketId);
+        verify(oddService).getById(oddId);
+        verify(repository).getByMarketAndOdd(market, odd);
+    }
+
+    @Test
+    public void getByOdd() {
+        final long oddId = 1L;
+        final OddsLeon odd = mock(OddsLeon.class);
+        final List<RunnerLeon> runnerLeonList = Arrays.asList(mock(RunnerLeon.class), mock(RunnerLeon.class));
+        when(oddService.getById(oddId)).thenReturn(odd);
+        when(repository.getByOdd(odd)).thenReturn(runnerLeonList);
+
+        final List<RunnerLeon> result = runnerLeonService.getByOdd(oddId);
+
+        assertThat(result, is(runnerLeonList));
+        verify(oddService).getById(oddId);
+        verify(repository).getByOdd(odd);
+    }
+
+    @Test
+    public void getAll() {
+        final List<RunnerLeon> runnerLeonList = Arrays.asList(mock(RunnerLeon.class), mock(RunnerLeon.class));
+        when(repository.findAll()).thenReturn(runnerLeonList);
+
+        final List<RunnerLeon> result = runnerLeonService.getAll();
+
+        assertThat(result, is(runnerLeonList));
+        verify(repository).findAll();
+    }
+
+    @Test
+    public void save() {
+        final RunnerLeon runner = mock(RunnerLeon.class);
+        when(repository.save(runner)).thenReturn(runner);
+
+        final RunnerLeon result = runnerLeonService.save(runner);
+
+        assertThat(result, is(runner));
+        verify(repository).save(runner);
+    }
+
+    @Test
+    public void delete() {
+        final RunnerLeon runner = mock(RunnerLeon.class);
+
+        runnerLeonService.delete(runner);
+
+        verify(repository).delete(runner);
+    }
+
+    @Test
+    public void getById() {
+        final long id = 1L;
+        final RunnerLeon runner = mock(RunnerLeon.class);
+        when(repository.getOne(id)).thenReturn(runner);
+
+        final RunnerLeon result = runnerLeonService.getById(id);
+
+        assertThat(result, is(runner));
+        verify(repository).getOne(id);
+    }
+
+    @Test
+    public void deleteAllByOddId() {
+        final long oddId = 1L;
+        final OddsLeon odd = mock(OddsLeon.class);
+        when(oddService.getById(oddId)).thenReturn(odd);
+
+        runnerLeonService.deleteAllByOddId(oddId);
+
+        verify(oddService).getById(oddId);
+        verify(repository).deleteAllByOdd(odd);
+    }
+
+    @Test
+    public void saveAll() {
+        final List<RunnerLeon> runnerLeonList = Arrays.asList(mock(RunnerLeon.class), mock(RunnerLeon.class));
+        when(repository.save(any())).thenAnswer(it -> it.getArgument(0));
+
+        final List<RunnerLeon> result = runnerLeonService.saveAll(runnerLeonList);
+
+        assertThat(result, is(runnerLeonList));
+        verify(repository, times(runnerLeonList.size())).save(any());
+    }
+}


### PR DESCRIPTION
- Для исключения рекурсий в `CompetitorLeon` добавлены исключения связанных сущностей из `equals` и `toString`
- Во всех сервисах Leon добавлена поддержка транзакций, а для методов выборки данных отдельно транзакции только для чтения
- Добавлены unit-тесты сервисов: 
  - `LeagueLeonServiceImpl`
  - `MarketLeonServiceImpl`
  - `CompetitorLeonServiceImpl`
  - `OddsLeonServiceImpl`
  - `RunnerLeonServiceImpl`
- Рефакторинг и unit-тесты конвертеров:
  - `CompetitorLeonDTOToCompetitorLeonConverter`
  - `LeagueLeonDTOToLeagueLeonConverter`
  - `OddsLeonDTOToOddsLeonConverter`
- Добавлены конвертеры и unit-тесты:
  - `MarketLeonDTOToMarketLeonConverter`
  - `MarketLeonDTOToRunnerLeonListConverter`
- Рефакторинг `LeonParsingController`, сокращены прямые конвертации данных, теперь они производятся специализированными конвертерами через систему конвертации типов