### PR TITLE
Доработка хранения даты в `CurrencyRate`

### DIFF
--- a/src/main/java/ru/kappers/model/CurrencyRate.java
+++ b/src/main/java/ru/kappers/model/CurrencyRate.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
 import java.math.BigDecimal;
-import java.sql.Date;
+import java.time.LocalDate;
 
 @Slf4j
 @Data
@@ -20,8 +20,8 @@ public class CurrencyRate {
     @Column(name = "id", nullable = false, insertable = false, updatable = false)
     @EqualsAndHashCode.Exclude
     private int id;
-    @Column(name="date")
-    private Date date;
+    @Column(name="date", columnDefinition = "DATE")
+    private LocalDate date;
     @Column(name="charcode")
     private String charCode;
     @Column(name="numcode")

--- a/src/main/java/ru/kappers/repository/CurrRateRepository.java
+++ b/src/main/java/ru/kappers/repository/CurrRateRepository.java
@@ -2,18 +2,15 @@ package ru.kappers.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import ru.kappers.model.CurrencyRate;
-import ru.kappers.model.Event;
 
-import java.sql.Date;
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.List;
 
 public interface CurrRateRepository extends JpaRepository<CurrencyRate, Integer> {
-   boolean existsCurrencyRateByDateAndCharCode(Date date, String currLiteral);
-   CurrencyRate getCurrencyRateByDateAndCharCode(Date date, String currLiteral);
+   boolean existsCurrencyRateByDateAndCharCode(LocalDate date, String currLiteral);
+   CurrencyRate getCurrencyRateByDateAndCharCode(LocalDate date, String currLiteral);
    void deleteAll();
-   List<CurrencyRate> getAllByDate(Date timestamp);
+   List<CurrencyRate> getAllByDate(LocalDate date);
 
 
 }

--- a/src/main/java/ru/kappers/service/CurrRateService.java
+++ b/src/main/java/ru/kappers/service/CurrRateService.java
@@ -1,9 +1,7 @@
 package ru.kappers.service;
 
 import ru.kappers.model.CurrencyRate;
-import ru.kappers.repository.CurrRateRepository;
 
-import java.sql.Date;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -12,11 +10,11 @@ import java.util.List;
  */
 public interface CurrRateService {
     CurrencyRate save(CurrencyRate rate);
-    boolean isExist (Date date, String currLiteral);
-    CurrencyRate getCurrByDate (Date date, String currLiteral);
+    boolean isExist (LocalDate date, String currLiteral);
+    CurrencyRate getCurrByDate (LocalDate date, String currLiteral);
     void clear ();
     CurrencyRate update (CurrencyRate rate);
     CurrencyRate getToday (String literal);
     List<CurrencyRate> getAllToday();
-    List<CurrencyRate> getAllByDate(Date date);
+    List<CurrencyRate> getAllByDate(LocalDate date);
 }

--- a/src/main/java/ru/kappers/service/impl/CurrRateServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/CurrRateServiceImpl.java
@@ -9,7 +9,6 @@ import ru.kappers.model.CurrencyRate;
 import ru.kappers.repository.CurrRateRepository;
 import ru.kappers.service.CurrRateService;
 
-import java.sql.Date;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -38,7 +37,7 @@ public class CurrRateServiceImpl implements CurrRateService {
 
     @Override
     @Transactional(readOnly = true)
-    public boolean isExist(Date date, String currLiteral) {
+    public boolean isExist(LocalDate date, String currLiteral) {
         log.debug("isExist(date: {}, currLiteral: {})...", date, currLiteral);
         if (currLiteral.equals(kappersProperties.getRubCurrencyCode())) return true;
         return getCurrByDate(date, currLiteral) != null;
@@ -46,7 +45,7 @@ public class CurrRateServiceImpl implements CurrRateService {
 
     @Override
     @Transactional(readOnly = true)
-    public CurrencyRate getCurrByDate(Date date, String currLiteral) {
+    public CurrencyRate getCurrByDate(LocalDate date, String currLiteral) {
         log.debug("getCurrByDate(date: {}, currLiteral: {})...", date, currLiteral);
         return repository.getCurrencyRateByDateAndCharCode(date, currLiteral);
     }
@@ -72,19 +71,19 @@ public class CurrRateServiceImpl implements CurrRateService {
     @Transactional(readOnly = true)
     public CurrencyRate getToday(String literal) {
         log.debug("getToday(literal: {})...", literal);
-        return getCurrByDate(Date.valueOf(LocalDate.now()), literal);
+        return getCurrByDate(LocalDate.now(), literal);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<CurrencyRate> getAllToday() {
         log.debug("getAllToday()...");
-        return getAllByDate(Date.valueOf(LocalDate.now()));
+        return getAllByDate(LocalDate.now());
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<CurrencyRate> getAllByDate(Date date) {
+    public List<CurrencyRate> getAllByDate(LocalDate date) {
         log.debug("getAllByDate(date: {})...", date);
         return repository.getAllByDate(date);
     }

--- a/src/main/java/ru/kappers/service/impl/CurrencyServiceImpl.java
+++ b/src/main/java/ru/kappers/service/impl/CurrencyServiceImpl.java
@@ -16,7 +16,6 @@ import ru.kappers.service.parser.CBRFDailyCurrencyRatesParser;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.sql.Date;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -78,7 +77,7 @@ public class CurrencyServiceImpl implements CurrencyService {
         }
     }
 
-    public Date getActualCurrencyRateDate(Date date, String fromCurr, String toCurr, boolean currRatesGotToday) {
+    public LocalDate getActualCurrencyRateDate(LocalDate date, String fromCurr, String toCurr, boolean currRatesGotToday) {
         log.debug("getActualCurrencyRateDate(date: {}, fromCurr: {}, toCurr: {}, currRatesGotToday: {})...",
                 date, fromCurr, toCurr, currRatesGotToday);
         boolean todaysCurrRatesGot = currRatesGotToday;
@@ -90,8 +89,8 @@ public class CurrencyServiceImpl implements CurrencyService {
             }
             if (todaysCurrRatesGot) {
                 if (!currRateService.isExist(date, fromCurr) || !currRateService.isExist(date, toCurr)) {
-                    LocalDate localDate = date.toLocalDate().minusDays(1);
-                    date = getActualCurrencyRateDate(Date.valueOf(localDate), fromCurr, toCurr, todaysCurrRatesGot);
+                    LocalDate localDate = date.minusDays(1);
+                    date = getActualCurrencyRateDate(localDate, fromCurr, toCurr, todaysCurrRatesGot);
                 }
             }
         }
@@ -109,7 +108,7 @@ public class CurrencyServiceImpl implements CurrencyService {
         if (fromCurr.equals(toCurr)) {
             return amount;
         }
-        Date date = getActualCurrencyRateDate(Date.valueOf(LocalDate.now()), fromCurr, toCurr, false);
+        LocalDate date = getActualCurrencyRateDate(LocalDate.now(), fromCurr, toCurr, false);
         final RoundingMode roundingMode = kappersProperties.getBigDecimalRoundingMode();
         final String rubCurrencyCode = kappersProperties.getRubCurrencyCode();
         if (fromCurr.equals(rubCurrencyCode)) {

--- a/src/main/java/ru/kappers/service/parser/CBRFDailyCurrencyRatesParser.java
+++ b/src/main/java/ru/kappers/service/parser/CBRFDailyCurrencyRatesParser.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import ru.kappers.model.CurrencyRate;
-import ru.kappers.util.DateTimeUtil;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -16,7 +15,9 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.sql.Date;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -91,7 +92,8 @@ public class CBRFDailyCurrencyRatesParser {
     public List<CurrencyRate> parseFromJSON(String json) {
         log.debug("parseFromJSON(json: {})...", json);
         JsonObject object = (JsonObject) jsonParser.parse(json);
-        Date date = DateTimeUtil.parseSqlDateFromZonedDateTime(object.get("Date").getAsString());
+        LocalDate date = ZonedDateTime.parse(object.get("Date").getAsString(), DateTimeFormatter.ISO_ZONED_DATE_TIME)
+                .toLocalDate();
         JsonObject valutes = object.get("Valute").getAsJsonObject();
         if (valutes.size() == 0) {
             return Collections.emptyList();

--- a/src/main/java/ru/kappers/util/DateTimeUtil.java
+++ b/src/main/java/ru/kappers/util/DateTimeUtil.java
@@ -2,7 +2,6 @@ package ru.kappers.util;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -56,19 +55,6 @@ public final class DateTimeUtil {
 		ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_ZONED_DATE_TIME);
 		final Timestamp result = Timestamp.valueOf(zonedDateTime.toLocalDateTime());
 		log.debug("parseTimestampFromZonedDateTime(dateTime: {}) return result: {}", dateTime, result);
-		return result;
-	}
-
-	/**
-	 * Получить экземпляр {@link Date} из строки
-	 * @param dateTime строка с датой и временем в формате {@link DateTimeFormatter#ISO_ZONED_DATE_TIME}
-	 * @return экземпляр {@link Date}
-	 */
-	public static Date parseSqlDateFromZonedDateTime(String dateTime) {
-		log.debug("parseSqlDateFromZonedDateTime(dateTime: {})...", dateTime);
-		ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_ZONED_DATE_TIME);
-		final Date result = Date.valueOf(zonedDateTime.toLocalDate());
-		log.debug("parseSqlDateFromZonedDateTime(dateTime: {}) return result: {}", dateTime, result);
 		return result;
 	}
 

--- a/src/test/java/ru/kappers/service/CurrRateServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/CurrRateServiceImplTest.java
@@ -2,9 +2,7 @@ package ru.kappers.service;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
-import lombok.extern.log4j.Log4j;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +17,6 @@ import ru.kappers.KappersApplication;
 import ru.kappers.model.CurrencyRate;
 
 import java.math.BigDecimal;
-import java.sql.Date;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.List;
@@ -44,7 +41,7 @@ public class CurrRateServiceImplTest extends AbstractTransactionalJUnit4SpringCo
         CurrencyRate rate = CurrencyRate.builder()
                 .nominal(1)
                 .value(expectedValue)
-                .date(Date.valueOf("2018-11-23"))
+                .date(LocalDate.parse("2018-11-23"))
                 .charCode("BTC")
                 .numCode("000")
                 .name("Bitcoin")
@@ -56,24 +53,24 @@ public class CurrRateServiceImplTest extends AbstractTransactionalJUnit4SpringCo
         assertEquals(save.getCharCode(), "BTC");
         assertEquals(save.getName(), "Bitcoin");
         assertEquals(save.getNumCode(), "000");
-        assertEquals(save.getDate(), Date.valueOf(LocalDate.of(2018, Month.NOVEMBER, 23)));
+        assertEquals(save.getDate(), LocalDate.of(2018, Month.NOVEMBER, 23));
     }
 
     @Test
     public void isExist() {
-        assertTrue(service.isExist(Date.valueOf("2018-11-21"), "GLD"));
+        assertTrue(service.isExist(LocalDate.parse("2018-11-21"), "GLD"));
     }
 
     @Test
     public void getCurrByDate() {
-        CurrencyRate gld = service.getCurrByDate(Date.valueOf("2018-11-21"), "GLD");
+        CurrencyRate gld = service.getCurrByDate(LocalDate.parse("2018-11-21"), "GLD");
         assertNotNull(gld);
         assertEquals(gld.getNumCode(), "999");
     }
 
     @Test
     public void update() {
-        CurrencyRate gld = service.getCurrByDate(Date.valueOf("2018-11-21"), "GLD");
+        CurrencyRate gld = service.getCurrByDate(LocalDate.parse("2018-11-21"), "GLD");
         assertNotNull(gld);
         assertEquals(gld.getValue(), new BigDecimal("2000.0000"));
 
@@ -95,8 +92,8 @@ public class CurrRateServiceImplTest extends AbstractTransactionalJUnit4SpringCo
 
     @Test
     public void getAllByDate() {
-        List<CurrencyRate> allByDate = service.getAllByDate(Date.valueOf("2018-11-21"));
-        CurrencyRate gld = service.getCurrByDate(Date.valueOf("2018-11-21"), "GLD");
+        List<CurrencyRate> allByDate = service.getAllByDate(LocalDate.parse("2018-11-21"));
+        CurrencyRate gld = service.getCurrByDate(LocalDate.parse("2018-11-21"), "GLD");
         assertTrue(allByDate.contains(gld));
     }
 }

--- a/src/test/java/ru/kappers/service/impl/CurrencyServiceImplTest.java
+++ b/src/test/java/ru/kappers/service/impl/CurrencyServiceImplTest.java
@@ -15,7 +15,6 @@ import ru.kappers.service.MessageTranslator;
 import ru.kappers.service.parser.CBRFDailyCurrencyRatesParser;
 
 import java.math.BigDecimal;
-import java.sql.Date;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
@@ -39,7 +38,7 @@ public class CurrencyServiceImplTest {
 
     @Test
     public void refreshCurrencyRatesForTodayMustSaveRateIfTableHasNotRate() {
-        final Date currentDate = Date.valueOf(LocalDate.now());
+        final LocalDate currentDate = LocalDate.now();
         final String usdCharCode = "USD";
         final CurrencyRate currencyRate = CurrencyRate.builder()
                 .date(currentDate)
@@ -58,7 +57,7 @@ public class CurrencyServiceImplTest {
 
     @Test
     public void refreshCurrencyRatesForTodayIfTableHasRate() {
-        final Date currentDate = Date.valueOf(LocalDate.now());
+        final LocalDate currentDate = LocalDate.now();
         final String usdCharCode = "USD";
         final CurrencyRate currencyRate = CurrencyRate.builder()
                 .date(currentDate)
@@ -121,7 +120,7 @@ public class CurrencyServiceImplTest {
 
     @Test
     public void getActualCurrencyRateDateMustReturnDateFromParameterIfBothCurrencyExists() {
-        final Date date = Date.valueOf(LocalDate.now());
+        final LocalDate date = LocalDate.now();
         final String from = CurrencyUnit.EUR.getCode();
         final String to = CurrencyUnit.USD.getCode();
         final boolean currRatesGotToday = true;
@@ -129,7 +128,7 @@ public class CurrencyServiceImplTest {
         when(currRateService.isExist(date, to)).thenReturn(true);
         currencyService = spy(currencyService);
 
-        final Date result = currencyService.getActualCurrencyRateDate(date, from, to, currRatesGotToday);
+        final LocalDate result = currencyService.getActualCurrencyRateDate(date, from, to, currRatesGotToday);
 
         assertThat(result, is(date));
         verify(currRateService).isExist(date, from);
@@ -139,7 +138,7 @@ public class CurrencyServiceImplTest {
 
     @Test
     public void getActualCurrencyRateDateMustReturnDateFromParameterIfCurrencyNotExistsAndRefreshFail() {
-        final Date date = Date.valueOf(LocalDate.now());
+        final LocalDate date = LocalDate.now();
         final String from = CurrencyUnit.EUR.getCode();
         final String to = CurrencyUnit.USD.getCode();
         final boolean currRatesGotToday = false;
@@ -147,7 +146,7 @@ public class CurrencyServiceImplTest {
         currencyService = spy(currencyService);
         doReturn(false).when(currencyService).refreshCurrencyRatesForToday();
 
-        final Date result = currencyService.getActualCurrencyRateDate(date, from, to, currRatesGotToday);
+        final LocalDate result = currencyService.getActualCurrencyRateDate(date, from, to, currRatesGotToday);
 
         assertThat(result, is(date));
         verify(currRateService).isExist(date, from);
@@ -158,8 +157,8 @@ public class CurrencyServiceImplTest {
     @Test
     public void getActualCurrencyRateDateMustReturnDateFromParameterIfCurrencyNotExistsAndRefreshSuccess() {
         final LocalDate now = LocalDate.now();
-        final Date date = Date.valueOf(now);
-        final Date date2 = Date.valueOf(now.minusDays(1));
+        final LocalDate date = now;
+        final LocalDate date2 = now.minusDays(1);
         final String from = CurrencyUnit.EUR.getCode();
         final String to = CurrencyUnit.USD.getCode();
         final boolean currRatesGotToday = false;
@@ -169,7 +168,7 @@ public class CurrencyServiceImplTest {
         currencyService = spy(currencyService);
         doReturn(true).when(currencyService).refreshCurrencyRatesForToday();
 
-        final Date result = currencyService.getActualCurrencyRateDate(date, from, to, currRatesGotToday);
+        final LocalDate result = currencyService.getActualCurrencyRateDate(date, from, to, currRatesGotToday);
 
         assertThat(result, is(date2));
         verify(currRateService, times(2)).isExist(date, from);
@@ -212,7 +211,7 @@ public class CurrencyServiceImplTest {
 
     @Test
     public void exchangeOneEURToUSD() {
-        final Date date = Date.valueOf(LocalDate.now());
+        final LocalDate date = LocalDate.now();
         final String from = CurrencyUnit.EUR.getCode();
         final String to = CurrencyUnit.USD.getCode();
         final BigDecimal amount = BigDecimal.ONE;
@@ -239,7 +238,7 @@ public class CurrencyServiceImplTest {
 
     @Test
     public void exchangeOneEURToRUB() {
-        final Date date = Date.valueOf(LocalDate.now());
+        final LocalDate date = LocalDate.now();
         final String from = CurrencyUnit.EUR.getCode();
         final String to = kappersProperties.getRubCurrencyCode();
         final BigDecimal amount = BigDecimal.ONE;
@@ -261,7 +260,7 @@ public class CurrencyServiceImplTest {
 
     @Test
     public void exchangeOneRUBToUSD() {
-        final Date date = Date.valueOf(LocalDate.now());
+        final LocalDate date = LocalDate.now();
         final String from = kappersProperties.getRubCurrencyCode();
         final String to = CurrencyUnit.USD.getCode();
         final BigDecimal amount = BigDecimal.ONE;

--- a/src/test/java/ru/kappers/service/parser/CBRFDailyCurrencyRatesParserTest.java
+++ b/src/test/java/ru/kappers/service/parser/CBRFDailyCurrencyRatesParserTest.java
@@ -7,7 +7,6 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.util.ResourceUtils;
 import ru.kappers.model.CurrencyRate;
-import ru.kappers.util.DateTimeUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +15,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -86,7 +86,7 @@ public class CBRFDailyCurrencyRatesParserTest {
         assertThat(usdCurrencyRate.getNumCode(), is("840"));
         assertThat(usdCurrencyRate.getCharCode(), is("USD"));
         assertThat(usdCurrencyRate.getName(), is("Доллар США"));
-        assertThat(usdCurrencyRate.getDate(), is(DateTimeUtil.parseSqlDateFromZonedDateTime("2019-05-17T11:30:00+03:00")));
+        assertThat(usdCurrencyRate.getDate(), is(LocalDate.parse("2019-05-17")));
         assertThat(usdCurrencyRate.getNominal(), is(1));
         assertThat(usdCurrencyRate.getValue(), is(new BigDecimal("64.5598")));
     }

--- a/src/test/java/ru/kappers/util/DateTimeUtilTest.java
+++ b/src/test/java/ru/kappers/util/DateTimeUtilTest.java
@@ -51,19 +51,4 @@ public class DateTimeUtilTest {
 	public void parseTimestampFromZonedDateTimeWithWrongFormat() {
 		DateTimeUtil.parseTimestampFromZonedDateTime("20011202T10:15:30+01:00");
 	}
-
-	@Test
-	public void parseSqlDateFromZonedDateTime() {
-		final ZonedDateTime expectedZonedDateTime = ZonedDateTime.of(
-				LocalDateTime.of(2001, Month.DECEMBER, 2, 10, 15, 30),
-				ZoneId.of("+02:00"));
-		final Date expectedDate = Date.valueOf(expectedZonedDateTime.toLocalDate());
-		final Date parsedDate = DateTimeUtil.parseSqlDateFromZonedDateTime("2001-12-02T10:15:30+02:00");
-		assertEquals(expectedDate, parsedDate);
-	}
-
-	@Test(expected = DateTimeParseException.class)
-	public void parseSqlDateFromZonedDateTimeWithWrongFormat() {
-		DateTimeUtil.parseSqlDateFromZonedDateTime("20011202T10:15:30+01:00");
-	}
 }


### PR DESCRIPTION
- Теперь в `CurrencyRate` дата хранится в `java.time.LocalDate`
- Доработаны репозитории, сервисы, парсер
- В утилитном классе `DateTimeUtil` удален метод `parseSqlDateFromZonedDateTime()`
- Доработаны интеграционные и unit-тесты

https://github.com/SuleymanovRA/kappers/pull/15