### PR TITLE
Add `Swagger` for REST API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <kotlin.version>1.3.50</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <maven.compiler.version>3.5.1</maven.compiler.version>
+        <springfox.swagger.version>2.9.2</springfox.swagger.version>
     </properties>
 
 <!-- Для централизованного управления зависимостями их версии указываем по возможности только здесь, как и исключения в них -->
@@ -95,6 +96,18 @@
                 <artifactId>kotlin-test</artifactId>
                 <version>${kotlin.version}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <!-- Swagger -->
+            <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-swagger2</artifactId>
+                <version>${springfox.swagger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-swagger-ui</artifactId>
+                <version>${springfox.swagger.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -260,12 +273,26 @@
                     <artifactId>usertype.core</artifactId>
                 </dependency>
         -->
+        <!-- Swagger -->
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+        </dependency>
     </dependencies>
 
     <repositories>
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
+        </repository>
+        <repository>
+            <id>jcenter-snapshots</id>
+            <name>jcenter</name>
+            <url>https://jcenter.bintray.com/</url>
         </repository>
     </repositories>
 

--- a/src/main/java/ru/kappers/config/SecurityConfig.java
+++ b/src/main/java/ru/kappers/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -42,7 +43,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable()
+        http
+                .csrf().disable()
                 .authorizeRequests()
                 .antMatchers(
                         "/",
@@ -56,6 +58,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         "/rest/dict/**"
                 ).permitAll()
                 .antMatchers("/rest/api/fixtures/twoweeks").hasAnyAuthority(Role.Names.ADMIN)
+                .antMatchers(
+                        HttpMethod.GET,
+                        "/v2/api-docs",
+                        "/swagger-resources/**",
+                        "/swagger-ui.html**",
+                        "/webjars/**",
+                        "favicon.ico"
+                        ).permitAll()
                 .anyRequest().authenticated()
 //                .and()
 //                .sessionManagement().maximumSessions(10)

--- a/src/main/kotlin/ru/kappers/config/SwaggerConfig.kt
+++ b/src/main/kotlin/ru/kappers/config/SwaggerConfig.kt
@@ -1,0 +1,32 @@
+package ru.kappers.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import springfox.documentation.swagger2.annotations.EnableSwagger2
+import springfox.documentation.builders.RequestHandlerSelectors
+import springfox.documentation.service.ApiInfo
+import springfox.documentation.service.BasicAuth
+import springfox.documentation.service.Contact
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spring.web.plugins.Docket
+
+@Configuration
+@EnableSwagger2
+open class SwaggerConfig {
+    @Bean
+    open fun productApi(): Docket {
+        return Docket(DocumentationType.SWAGGER_2)
+                .securitySchemes(arrayListOf(BasicAuth("basicAuth")))
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("ru.kappers.logic.controller"))
+                .build()
+    }
+
+    private fun apiInfo(): ApiInfo {
+        return ApiInfo("Kappers API Documents", "Kappers service API Documents",
+                "v1", "https://github.com/soufee/kappers",
+                Contact("Ashamaz Shomakhov", "https://github.com/soufee/kappers", "soufee@mail.ru"),
+                "Kappers Copyright", "https://github.com/soufee/kappers", emptyList())
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -11,6 +11,7 @@ spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults = false
 spring.jpa.open-in-view=false
 spring.mvc.view.prefix=/
 spring.mvc.view.suffix=.html
+spring.resources.add-mappings=true
 
 #spring.flyway.locations=classpath:db/migration,classpath:dev/db/migration
 spring.flyway.baseline-on-migrate=true


### PR DESCRIPTION
- add `springfox-swagger2` dependency
- add `springfox-swagger-ui` dependency
- now for view swagger-ui on web-browser you can go to link http://host:port/swagger-ui.html
- now for view swagger JSON file you can go to link http://host:port/v2/api-docs or from link http://host:port/swagger-ui.html
- add `SwaggerConfig` class for config Swagger 2