### PR TITLE
Add `Swagger` for REST API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,11 +289,6 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
-        <repository>
-            <id>jcenter-snapshots</id>
-            <name>jcenter</name>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
- delete `jcenter-snapshots` repository